### PR TITLE
proof-producer: add assignment table writer

### DIFF
--- a/proof-producer/CMakeLists.txt
+++ b/proof-producer/CMakeLists.txt
@@ -74,3 +74,4 @@ endif()
 set(CPACK_PACKAGING_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX})
 
 add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/bin/proof-producer")
+add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/libs/output_artifacts")

--- a/proof-producer/bin/proof-producer/CMakeLists.txt
+++ b/proof-producer/bin/proof-producer/CMakeLists.txt
@@ -61,9 +61,14 @@ function(setup_proof_generator_target)
     )
 
     target_link_libraries(${ARG_TARGET_NAME}-lib INTERFACE ${INTERFACE_LIBS})
-    target_link_libraries(${ARG_TARGET_NAME} PRIVATE ${ARG_TARGET_NAME}-lib Boost::program_options)
+    target_link_libraries(${ARG_TARGET_NAME} PRIVATE 
+        ${ARG_TARGET_NAME}-lib 
+        Boost::program_options
+        proof_generatorOutputArtifacts
+    )
 
     target_include_directories(${ARG_TARGET_NAME} PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/include
         ${CMAKE_CURRENT_SOURCE_DIR}/src
     )
 

--- a/proof-producer/libs/output_artifacts/CMakeLists.txt
+++ b/proof-producer/libs/output_artifacts/CMakeLists.txt
@@ -1,0 +1,22 @@
+add_library(proof_generatorOutputArtifacts INTERFACE)
+
+target_include_directories(proof_generatorOutputArtifacts
+    INTERFACE ${CMAKE_CURRENT_SOURCE_DIR}/include
+)
+
+find_package(Boost REQUIRED COMPONENTS filesystem log)
+if(ENABLE_TESTS)
+    find_package(Boost REQUIRED COMPONENTS unit_test_framework)
+endif()
+
+target_link_libraries(proof_generatorOutputArtifacts
+                      INTERFACE
+                      crypto3::common
+                      Boost::log
+)
+
+install(TARGETS proof_generatorOutputArtifacts
+        DESTINATION ${CMAKE_INSTALL_LIBDIR})
+        
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})

--- a/proof-producer/libs/output_artifacts/include/nil/proof-generator/assignment_table_writer.hpp
+++ b/proof-producer/libs/output_artifacts/include/nil/proof-generator/assignment_table_writer.hpp
@@ -1,0 +1,155 @@
+//---------------------------------------------------------------------------//
+// Copyright (c) 2024 Daniil Kogtev <oclaw@nil.foundation>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//---------------------------------------------------------------------------//
+
+#ifndef PROOF_GENERATOR_ASSIGNMENT_TABLE_WRITER_HPP
+#define PROOF_GENERATOR_ASSIGNMENT_TABLE_WRITER_HPP
+
+#include <boost/log/sources/record_ostream.hpp>
+#include <boost/log/trivial.hpp>
+#include <boost/assert.hpp>
+#include <ostream>  
+
+#include <nil/crypto3/marshalling/algebra/types/field_element.hpp>
+#include <nil/crypto3/zk/snark/arithmetization/plonk/assignment.hpp>
+#include <nil/marshalling/types/integral.hpp>
+
+
+namespace nil {
+    namespace proof_generator {
+
+        template <typename Endianness, typename BlueprintField>
+        class assignment_table_writer {
+            public:                
+                using Column = nil::crypto3::zk::snark::plonk_column<BlueprintField>;
+                using ArithmetizationType = nil::crypto3::zk::snark::plonk_constraint_system<BlueprintField>;
+
+                using AssignmentTable = nil::crypto3::zk::snark::plonk_table<BlueprintField, Column>; 
+                using AssignmentTableDescription = nil::crypto3::zk::snark::plonk_table_description<BlueprintField>;
+
+                // marshalling traits
+                using TTypeBase = nil::marshalling::field_type<Endianness>;
+                using BlueprintFieldValueType = typename BlueprintField::value_type;
+                using MarshallingField = nil::crypto3::marshalling::types::field_element<
+                    TTypeBase, 
+                    BlueprintFieldValueType
+                >;
+
+            private:            
+                /**
+                * @brief Write size_t serialized as nil::marshalling::types::integral into output stream.
+                */
+                static void write_size_t(std::ostream& out, size_t input) {
+                    auto integer_container = nil::marshalling::types::integral<TTypeBase, std::size_t>(input);
+                    std::array<std::uint8_t, integer_container.length()> char_array{};
+                    auto write_iter = char_array.begin();
+                    assert(integer_container.write(write_iter, char_array.size()) ==
+                        nil::marshalling::status_type::success);
+
+                    out.write(reinterpret_cast<char*>(char_array.data()), char_array.size());
+                }
+
+                /**
+                * @brief Write zero value serialized via crypto3 marshalling into output
+                * stream.
+                */
+                static void write_zero_field(std::ostream& out) {
+                    using empty_field = std::array<std::uint8_t, MarshallingField().length()>;
+                    
+                    empty_field field{};
+                    out.write(reinterpret_cast<char*>(field.data()), field.size());
+                }
+
+                /**
+                * @brief Write field element into output stream.
+                */
+                static void write_field(std::ostream& out, const BlueprintFieldValueType& input) {
+                    MarshallingField field_container(input);
+                    std::array<std::uint8_t, field_container.length()> char_array{};
+                    auto write_iter = char_array.begin();
+                    assert(field_container.write(write_iter, char_array.size()) ==
+                        nil::marshalling::status_type::success);
+
+                    out.write(reinterpret_cast<char*>(char_array.data()), char_array.size());
+                }
+
+
+                /**
+                * @brief Write table column to output stream padding with zeroes up to fixed number of values.
+                */
+                // template<typename Endianness, typename ArithmetizationType, typename ColumnType>
+                static void write_vector_value(std::ostream& out, const std::size_t padded_rows_amount, const Column& table_col) {
+                    for (std::size_t i = 0; i < padded_rows_amount; i++) {
+                        if (i < table_col.size()) {
+                            write_field(out,table_col[i]);
+                        } else {
+                            write_zero_field(out);
+                        }
+                    }
+                }
+
+
+            public:
+                assignment_table_writer() = delete;
+
+                static void write_binary_assignment(std::ostream& out, const AssignmentTable& table, const AssignmentTableDescription& desc) {
+                    std::uint32_t public_input_size = table.public_inputs_amount();
+                    std::uint32_t witness_size = table.witnesses_amount();
+                    std::uint32_t constant_size = table.constants_amount();
+                    std::uint32_t selector_size = table.selectors_amount();
+                    std::uint32_t usable_rows_amount = desc.usable_rows_amount;
+
+                    std::uint32_t padded_rows_amount = std::pow(2, std::ceil(std::log2(usable_rows_amount)));
+                    if (padded_rows_amount == usable_rows_amount) {
+                        padded_rows_amount *= 2;
+                    }
+                    if (padded_rows_amount < 8) {
+                        padded_rows_amount = 8;
+                    }
+                    
+                    write_size_t(out, witness_size);
+                    write_size_t(out, public_input_size);
+                    write_size_t(out, constant_size);
+                    write_size_t(out, selector_size);
+                    write_size_t(out, usable_rows_amount);
+                    write_size_t(out, padded_rows_amount);
+
+                    write_size_t(out, witness_size * padded_rows_amount);
+                    for (std::uint32_t i = 0; i < witness_size; i++) {
+                        write_vector_value(out, padded_rows_amount,table.witness(i));
+                    }
+
+                    write_size_t(out, public_input_size * padded_rows_amount);
+                    for (std::uint32_t i = 0; i < public_input_size; i++) {
+                        write_vector_value(out, padded_rows_amount, table.public_input(i));
+                    }
+
+                    write_size_t(out, constant_size * padded_rows_amount);
+                    for (std::uint32_t i = 0; i < constant_size; i++) {
+                        write_vector_value(out, padded_rows_amount,table.constant(i));
+                    }
+
+                    write_size_t(out, selector_size * padded_rows_amount);
+                    for (std::uint32_t i = 0; i < selector_size; i++) {
+                        write_vector_value(out, padded_rows_amount, table.selector(i));
+                    }
+                }
+        };
+
+    } // namespace proof_generator
+
+} // namespace nil
+
+#endif // PROOF_GENERATOR_ASSIGNMENT_TABLE_WRITER_HPP


### PR DESCRIPTION
Took an implementation from [write_assignments.hpp](https://github.com/NilFoundation/placeholder/blob/feature/proof-prioducer-assignment-table-writer/zkevm-framework/libs/assigner_runner/include/zkevm_framework/assigner_runner/write_assignments.hpp/#L91) 

Simplified it a bit, added usage of table description and unified template alias declarations
Checked with circuits and tables from the CI, saved tables are the same as provided