### PR TITLE
Fix : Nix installation command by correctly using the -L flag in curl…

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,7 @@ Supported by [=nil; Foundation](https://nil.foundation)
 Install nix using the following command:
 
 ```
-curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install
+ curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install
 ```
 
 ### Build


### PR DESCRIPTION
… command

correction of  the usage of the -L flag in the Nix installation command, ensuring that curl handles redirects properly. The -L flag is now correctly placed with a space separating it from the URL to avoid argument misinterpretation. This change resolves an error where curl was not following redirects as intended, improving the reliability of the installation command for all users