### PR TITLE
Fix incorrect curl option formatting in Nix installer command

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -16,7 +16,8 @@ Supported by [=nil; Foundation](https://nil.foundation)
 Install nix using the following command:
 
 ```
-curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install
+curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install
+
 ```
 
 ### Build


### PR DESCRIPTION
This PR corrects the formatting issue with the curl command by ensuring the -L option and URL are properly separated. Previously, -L was mistakenly combined with the URL, causing an "unknown option" error. This update follows the correct format to ensure successful execution of the Nix installation command.