### PR TITLE
fix: typos in documentation files

### DIFF
--- a/crypto3/docs/manual/index.md
+++ b/crypto3/docs/manual/index.md
@@ -10,7 +10,7 @@ Crypto3 cryptography suite's purpose is:
 
 Libraries are designed to be state of the art, highly performant and providing a one-stop solution for 
 all cryptographic operations. They are supported on all operating systems (*nix, windows, macOS) 
-and architectures(x86/ARM).
+and architectures (x86/ARM).
 
 
 See [contribution](contributing.md) guidelines if you wish to contribute to the project.
@@ -25,13 +25,13 @@ Detailed list of modules with tutorials is available at [Modules page](modules.h
 ```
 root
 ├── cmake: cmake sub-module with helper functions/macros to build crypto3 library umbrella-repository
-├── docs: documentation , tutorials and guides
+├── docs: documentation, tutorials and guides
 ├── libs: all directories added as submodules which are independent projects.
 │   ├── algebra: algebraic operations and structures being used for elliptic-curve cryptography
 │   ├── block: block ciphers
 │   ├── blueprint: components and circuits for zk schemes
 │   ├── codec: encoding/decoding algorithms
-│   ├── containers:containers and generic commitment schemes for accumulating data, includes Merkle Tree
+│   ├── containers: containers and generic commitment schemes for accumulating data, includes Merkle Tree
 │   ├── hash: hashing algorithms
 │   ├── kdf: key derivation functions 
 │   ├── mac: message authentication codes
@@ -69,7 +69,7 @@ project as a submodule and would not need to resolve dependencies. See [crypto3-
 
 ### Selective
 Developer can select to include a one or more modules to reduce the sources of resulting project and dependencies tree height. This however
-does require the developer to manually resolve all required dependencies and stay upto date regarding
+does require the developer to manually resolve all required dependencies and stay up to date regarding
 compatibilities across modules.
 
 

--- a/crypto3/docs/manual/intermediate.md
+++ b/crypto3/docs/manual/intermediate.md
@@ -4,7 +4,7 @@ BLS weighted threshold signature [WIP]
 =============================
 
 In this tutorial we dive deeper into the cryptography constructs which crypto3 library implements.
-By the end of this tutorial , a user will understand how to sign data and use different modes.
+By the end of this tutorial, a user will understand how to sign data and use different modes.
 
 
 Pre-requisites
@@ -38,7 +38,7 @@ which an algorithm needs to be performed.
 - Finalisation: This steps requires accumulated data to be finalised padded before running an algorithm.
 
 Algorithms in the crypto3 library will carry out the above steps for the user. Algorithms can do operations
-such as signing , aggregating , verifying.
+such as signing, aggregating, verifying.
 
 
 Starting point to use any public key operations in crypto3 library is to create a cryptographic scheme. 
@@ -74,7 +74,7 @@ using pubkey_type = public_key<scheme_type>;
 
 
 Next we set up some types which we will use throughout the example
-- `sss_public_key_group_type` : TODO : Describe them. Which one of these are accumulators?
+- `sss_public_key_group_type` : TODO: Describe them. Which one of these are accumulators?
 - `shares_dealing_processing_mode`
 - `signing_processing_mode_type`
 - `verification_processing_mode_type`
@@ -102,7 +102,7 @@ We now take a closer look at our main.
     std::size_t n = 20;
     std::size_t t = 10;
 ```
-Next , we assign weights to our threshold values using the `weights_type` type which is a pair of (TODO)
+Next, we assign weights to our threshold values using the `weights_type` type which is a pair of (TODO)
 
 ```c++
     auto i = 1;

--- a/crypto3/docs/manual/quickstart.md
+++ b/crypto3/docs/manual/quickstart.md
@@ -3,7 +3,7 @@
 Quickstart
 ========================
 
-By the end of this guide ,you will have set up a development environment for crypto3 projects 
+By the end of this guide, you will have set up a development environment for crypto3 projects 
 and be able to run an example.This will enable you to test ideas quickly and further explore the 
 API's of the suite.
 

--- a/crypto3/libs/block/docs/usage.md
+++ b/crypto3/libs/block/docs/usage.md
@@ -22,7 +22,7 @@ int main(int argc, char *argv[]) {
     std::string key = "\x2b\x7e\x15\x16\x28\xae\xd2\xa6\xab\xf7\x15\x88\x09\xcf\x4f\x3c";
 
 
-    std::string out = encrypt<block::aes<128>>(input.begn(), input.end(), key);
+    std::string out = encrypt<block::aes<128>>(input.begin(), input.end(), key);
 
     assert(out == "3ad77bb40d7a3660a89ecaf32466ef97f5d3d58503b9699de785895a96fdbaaf"
                     "43b1cd7f598ece23881b00e3ed0306887b0c785e27e8ad3f8223207104725dd4");

--- a/crypto3/libs/hash/docs/pack.md
+++ b/crypto3/libs/hash/docs/pack.md
@@ -162,7 +162,7 @@ struct1 [label="0x12 | 0x34 | 0x56 | 0x78 | 0x90 | 0xab | 0xcd | 0xef"];
 } @enddot
 
 Here it is easy to see that the data from `input` was just concatenated into the `output` data with no additional
-tranformations. Now, notice that the first and the second example described in this section implicitly rely on the
+transformations. Now, notice that the first and the second example described in this section implicitly rely on the
 above-described convention. In the first example the input data is concatenated in reverse byte order, and in the second
 example the byte order is reversed after the input data concatenation.
 

--- a/crypto3/libs/zk/docs/manual.md
+++ b/crypto3/libs/zk/docs/manual.md
@@ -27,7 +27,7 @@ bp.set_input_sizes(1);
 ```
 
 Note, that the first allocated variable on the blueprint is a constant 1. So, the variables on the blueprint would
-be `1` , `res`, `A[0]`, ..., `A[n-1]`, `B[0]`, ..., `B[n-1]`.
+be `1`, `res`, `A[0]`, ..., `A[n-1]`, `B[0]`, ..., `B[n-1]`.
 
 To specify which variables are public and which ones are private we use the function `set_input_sizes(1)`, so only `res`
 value is a primary input. Thus, usually, the primary input is allocated before the auxiliary input in the program.


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.
Description correction:

Corrected "begn" to "begin".
Corrected "tranformations" to "transformations" and also extra spaces were removed.

Please review the changes and let me know if any additional changes are needed before merging.