### PR TITLE
reduce prover memory usage

### DIFF
--- a/crypto3/libs/blueprint/include/nil/blueprint/blueprint/plonk/assignment.hpp
+++ b/crypto3/libs/blueprint/include/nil/blueprint/blueprint/plonk/assignment.hpp
@@ -332,20 +332,20 @@ namespace nil {
 
             virtual value_type &selector(std::size_t selector_index, std::uint32_t row_index) {
 
-                assert(selector_index < this->_public_table._selectors.size());
+                assert(selector_index < this->_public_table->_selectors.size());
 
-                if (this->_public_table._selectors[selector_index].size() <= row_index)
-                    this->_public_table._selectors[selector_index].resize(row_index + 1);
+                if (this->_public_table->_selectors[selector_index].size() <= row_index)
+                    this->_public_table->_selectors[selector_index].resize(row_index + 1);
 
-                return this->_public_table._selectors[selector_index][row_index];
+                return this->_public_table->_selectors[selector_index][row_index];
             }
 
             virtual value_type selector(std::size_t selector_index, std::uint32_t row_index) const {
 
-                assert(selector_index < this->_public_table._selectors.size());
-                assert(row_index < this->_public_table._selectors[selector_index].size());
+                assert(selector_index < this->_public_table->_selectors.size());
+                assert(row_index < this->_public_table->_selectors[selector_index].size());
 
-                return this->_public_table._selectors[selector_index][row_index];
+                return this->_public_table->_selectors[selector_index][row_index];
             }
 
             virtual const column_type& selector(std::uint32_t index) const {
@@ -425,22 +425,22 @@ namespace nil {
             virtual value_type &witness(std::uint32_t witness_index, std::uint32_t row_index) {
                 BLUEPRINT_ASSERT(witness_index < this->_private_table._witnesses.size());
 
-                if (this->_private_table._witnesses[witness_index].size() <= row_index)
-                    this->_private_table._witnesses[witness_index].resize(row_index + 1);
+                if (this->_private_table->_witnesses[witness_index].size() <= row_index)
+                    this->_private_table->_witnesses[witness_index].resize(row_index + 1);
 
                 assignment_allocated_rows = std::max(assignment_allocated_rows, row_index + 1);
-                return this->_private_table._witnesses[witness_index][row_index];
+                return this->_private_table->_witnesses[witness_index][row_index];
             }
 
             virtual value_type witness(std::uint32_t witness_index, std::uint32_t row_index) const {
-                BLUEPRINT_RELEASE_ASSERT(witness_index < this->_private_table._witnesses.size());
-                BLUEPRINT_RELEASE_ASSERT(row_index < this->_private_table._witnesses[witness_index].size());
+                BLUEPRINT_RELEASE_ASSERT(witness_index < this->_private_table->_witnesses.size());
+                BLUEPRINT_RELEASE_ASSERT(row_index < this->_private_table->_witnesses[witness_index].size());
 
-                return this->_private_table._witnesses[witness_index][row_index];
+                return this->_private_table->_witnesses[witness_index][row_index];
             }
 
             virtual std::uint32_t witness_column_size(std::uint32_t col_idx) const {
-                return this->_private_table.witness_column_size(col_idx);
+                return this->_private_table->witness_column_size(col_idx);
             }
 
             virtual std::uint32_t witnesses_amount() const {
@@ -457,9 +457,9 @@ namespace nil {
                 BLUEPRINT_ASSERT(public_input_index < zk_type::public_inputs_amount());
 
                 if (zk_type::public_input_column_size(public_input_index) <= row_index)
-                    this->_public_table._public_inputs[public_input_index].resize(row_index + 1);
+                    this->_public_table->_public_inputs[public_input_index].resize(row_index + 1);
 
-                return this->_public_table._public_inputs[public_input_index][row_index];
+                return this->_public_table->_public_inputs[public_input_index][row_index];
             }
 
             virtual value_type public_input(
@@ -472,7 +472,7 @@ namespace nil {
             }
 
             virtual std::uint32_t public_input_column_size(std::uint32_t col_idx) const {
-                return this->_public_table.public_input_column_size(col_idx);
+                return this->_public_table->public_input_column_size(col_idx);
             }
 
             virtual std::uint32_t public_inputs_amount() const {
@@ -489,10 +489,10 @@ namespace nil {
                 BLUEPRINT_ASSERT(constant_index < zk_type::constants_amount());
 
                 if (zk_type::constant_column_size(constant_index) <= row_index)
-                    this->_public_table._constants[constant_index].resize(row_index + 1);
+                    this->_public_table->_constants[constant_index].resize(row_index + 1);
 
                 assignment_allocated_rows = std::max(assignment_allocated_rows, row_index + 1);
-                return this->_public_table._constants[constant_index][row_index];
+                return this->_public_table->_constants[constant_index][row_index];
             }
 
             virtual value_type constant(
@@ -522,7 +522,7 @@ namespace nil {
             }
 
             virtual std::uint32_t constant_column_size(std::uint32_t col_idx) const {
-                return this->_public_table.constant_column_size(col_idx);
+                return this->_public_table->constant_column_size(col_idx);
             }
 
             virtual std::uint32_t constants_amount() const {
@@ -599,9 +599,9 @@ namespace nil {
             /// @brief Max size of witness columns.
             std::uint32_t max_witnesses_size() const {
                 std::uint32_t size = 0;
-                std::size_t ammount = this->_private_table.witnesses_amount();
+                std::size_t ammount = this->_private_table->witnesses_amount();
                 for (std::uint32_t i = 0; i < ammount; i++) {
-                    size = std::max(size, this->_private_table.witness_column_size(i));
+                    size = std::max(size, this->_private_table->witness_column_size(i));
                 }
                 return size;
             }
@@ -609,9 +609,9 @@ namespace nil {
             /// @brief Max size of public input columns.
             std::uint32_t max_public_inputs_size() const {
                 std::uint32_t size = 0;
-                std::size_t ammount = this->_public_table.public_inputs_amount();
+                std::size_t ammount = this->_public_table->public_inputs_amount();
                 for (std::uint32_t i = 0; i < ammount; i++) {
-                    size = std::max(size, this->_public_table.public_input_column_size(i));
+                    size = std::max(size, this->_public_table->public_input_column_size(i));
                 }
                 return size;
             }
@@ -619,9 +619,9 @@ namespace nil {
             /// @brief Max size of constant columns.
             std::uint32_t max_constants_size() const {
                 std::uint32_t size = 0;
-                std::size_t ammount = this->_public_table.constants_amount();
+                std::size_t ammount = this->_public_table->constants_amount();
                 for (std::uint32_t i = 0; i < ammount; i++) {
-                    size = std::max(size, this->_public_table.constant_column_size(i));
+                    size = std::max(size, this->_public_table->constant_column_size(i));
                 }
                 return size;
             }
@@ -629,9 +629,9 @@ namespace nil {
             /// @brief Max size of selector columns.
             std::uint32_t max_selectors_size() const {
                 std::uint32_t size = 0;
-                std::size_t ammount = this->_public_table.selectors_amount();
+                std::size_t ammount = this->_public_table->selectors_amount();
                 for (std::uint32_t i = 0; i < ammount; i++) {
-                    size = std::max(size, this->_public_table.selector_column_size(i));
+                    size = std::max(size, this->_public_table->selector_column_size(i));
                 }
                 return size;
             }
@@ -642,11 +642,12 @@ namespace nil {
                     {max_witnesses_size(), max_public_inputs_size(), max_constants_size(), max_selectors_size()});
             }
 
+            // todo delete this impl as soon as old zkevm is removed
             virtual void export_table(std::ostream &os, bool wide_export = false) const {
-                std::size_t witnesses_size = this->_private_table.witnesses_amount(),
-                            public_size = this->_public_table.public_inputs_amount(),
-                            constants_size = this->_public_table.constants_amount(),
-                            selectors_size = this->_public_table.selectors_amount();
+                std::size_t witnesses_size = this->_private_table->witnesses_amount(),
+                            public_size = this->_public_table->public_inputs_amount(),
+                            constants_size = this->_public_table->constants_amount(),
+                            selectors_size = this->_public_table->selectors_amount();
                 std::uint32_t size = this->max_size();
 
                 ranges rows;
@@ -680,10 +681,10 @@ namespace nil {
                                       ranges selectors, ranges rows, bool wide_export = false) const {
                 // wide_export is for e.g. potentiall fuzzer: does fixed width elements
                 std::ios_base::fmtflags os_flags(os.flags());
-                std::size_t total_witnesses_size = this->_private_table.witnesses_amount(),
-                            total_public_size = this->_public_table.public_inputs_amount(),
-                            total_constants_size = this->_public_table.constants_amount(),
-                            total_selectors_size = this->_public_table.selectors_amount();
+                std::size_t total_witnesses_size = this->_private_table->witnesses_amount(),
+                            total_public_size = this->_public_table->public_inputs_amount(),
+                            total_constants_size = this->_public_table->constants_amount(),
+                            total_selectors_size = this->_public_table->selectors_amount();
                 std::uint32_t total_size = this->max_size();
 
                 os << std::dec;
@@ -702,8 +703,8 @@ namespace nil {
                         for (auto [lower_witness, upper_witness] : witnesses) {
                             for (std::uint32_t j = lower_witness; j <= upper_witness; j++) {
                                 os << std::setw(width)
-                                   << (i < this->_private_table.witness_column_size(j) ?
-                                           this->_private_table.witness(j)[i] :
+                                   << (i < this->_private_table->witness_column_size(j) ?
+                                           this->_private_table->witness(j)[i] :
                                            0)
                                           .data
                                    << " ";
@@ -713,8 +714,8 @@ namespace nil {
                         for (auto [lower_public_input, upper_public_input] : public_inputs) {
                             for (std::uint32_t j = lower_public_input; j <= upper_public_input; j++) {
                                 os << std::setw(width)
-                                   << (i < this->_public_table.public_input_column_size(j) ?
-                                           this->_public_table.public_input(j)[i] :
+                                   << (i < this->_public_table->public_input_column_size(j) ?
+                                           this->_public_table->public_input(j)[i] :
                                            0)
                                           .data
                                    << " ";
@@ -724,8 +725,8 @@ namespace nil {
                         for (auto [lower_constant, upper_constant] : constants) {
                             for (std::uint32_t j = lower_constant; j <= upper_constant; j++) {
                                 os << std::setw(width)
-                                   << (i < this->_public_table.constant_column_size(j) ?
-                                           this->_public_table.constant(j)[i] :
+                                   << (i < this->_public_table->constant_column_size(j) ?
+                                           this->_public_table->constant(j)[i] :
                                            0)
                                           .data
                                    << " ";
@@ -735,8 +736,8 @@ namespace nil {
                         for (auto [lower_selector, upper_selector] : selectors) {
                             // Selectors only need a single bit, so we do not renew the size here
                             for (std::uint32_t j = lower_selector; j <= upper_selector; j++) {
-                                os << (i < this->_public_table.selector_column_size(j) ?
-                                           this->_public_table.selector(j)[i] :
+                                os << (i < this->_public_table->selector_column_size(j) ?
+                                           this->_public_table->selector(j)[i] :
                                            0)
                                           .data
                                    << " ";

--- a/crypto3/libs/blueprint/test/verifiers/placeholder/verifier.cpp
+++ b/crypto3/libs/blueprint/test/verifiers/placeholder/verifier.cpp
@@ -294,14 +294,14 @@ gen_test_proof(
     typename nil::crypto3::zk::snark::placeholder_public_preprocessor<
         field_type, src_placeholder_params>::preprocessed_data_type public_preprocessed_data =
     nil::crypto3::zk::snark::placeholder_public_preprocessor<field_type, src_placeholder_params>::process(
-        constraint_system, assignment_table.move_public_table(), table_description, lpc_scheme
+        constraint_system, assignment_table.public_table(), table_description, lpc_scheme
     );
 
     std::cout <<"Preprocess private data" << std::endl;
     typename nil::crypto3::zk::snark::placeholder_private_preprocessor<
         field_type, src_placeholder_params>::preprocessed_data_type private_preprocessed_data =
         nil::crypto3::zk::snark::placeholder_private_preprocessor<field_type, src_placeholder_params>::process(
-            constraint_system, assignment_table.move_private_table(), table_description
+            constraint_system, assignment_table.private_table(), table_description
         );
 
     std::cout <<"Generate proof" << std::endl;

--- a/crypto3/libs/marshalling/zk/include/nil/crypto3/marshalling/zk/types/placeholder/preprocessed_public_data.hpp
+++ b/crypto3/libs/marshalling/zk/include/nil/crypto3/marshalling/zk/types/placeholder/preprocessed_public_data.hpp
@@ -78,7 +78,7 @@ namespace nil {
 
                     return result_type(std::make_tuple(
                         fill_plonk_public_table<Endianness, typename PreprocessedPublicDataType::plonk_public_polynomial_dfs_table_type>(
-                            preprocessed_public_data.public_polynomial_table),
+                            *preprocessed_public_data.public_polynomial_table),
                         fill_polynomial_vector<Endianness, PolynomialDFSType>(preprocessed_public_data.permutation_polynomials),
                         fill_polynomial_vector<Endianness, PolynomialDFSType>(preprocessed_public_data.identity_polynomials),
                         fill_polynomial<Endianness, PolynomialDFSType>(preprocessed_public_data.q_last),

--- a/crypto3/libs/marshalling/zk/include/nil/crypto3/marshalling/zk/types/plonk/assignment_table.hpp
+++ b/crypto3/libs/marshalling/zk/include/nil/crypto3/marshalling/zk/types/plonk/assignment_table.hpp
@@ -25,6 +25,7 @@
 #ifndef CRYPTO3_MARSHALLING_ZK_PLONK_ASSIGNMENT_TABLE_HPP
 #define CRYPTO3_MARSHALLING_ZK_PLONK_ASSIGNMENT_TABLE_HPP
 
+#include <memory>
 #include <type_traits>
 
 #include <nil/crypto3/zk/snark/arithmetization/plonk/constraint_system.hpp>
@@ -278,9 +279,16 @@ namespace nil {
                             desc.rows_amount
                         );
 
+                    using private_table = typename PlonkTable::private_table_type;
+                    using public_table = typename PlonkTable::public_table_type;
+
                     return std::make_pair(desc, PlonkTable(
-                        typename PlonkTable::private_table_type(witnesses),
-                        typename PlonkTable::public_table_type(public_inputs, constants, selectors)
+                        std::make_shared<private_table>(std::move(witnesses)),
+                        std::make_shared<public_table>(
+                            std::move(public_inputs), 
+                            std::move(constants), 
+                            std::move(selectors)
+                        )
                     ));
                 }
 

--- a/crypto3/libs/marshalling/zk/include/nil/crypto3/marshalling/zk/types/plonk/plonk_public_polynomial_dfs_table.hpp
+++ b/crypto3/libs/marshalling/zk/include/nil/crypto3/marshalling/zk/types/plonk/plonk_public_polynomial_dfs_table.hpp
@@ -71,12 +71,12 @@ namespace nil {
                 }
 
                 template<typename Endianness, typename PlonkPublicTable>
-                PlonkPublicTable make_plonk_public_table(
+                std::shared_ptr<PlonkPublicTable> make_plonk_public_table(
                         const plonk_public_polynomial_table<nil::marshalling::field_type<Endianness>, PlonkPublicTable> &filled_public_table) {
                     using TTypeBase = nil::marshalling::field_type<Endianness>;
                     using PolynomialType = typename PlonkPublicTable::column_type;
  
-                    return PlonkPublicTable(
+                    return std::make_shared<PlonkPublicTable>(
                         make_polynomial_vector<Endianness, PolynomialType>(std::get<0>(filled_public_table.value())),
                         make_polynomial_vector<Endianness, PolynomialType>(std::get<1>(filled_public_table.value())),
                         make_polynomial_vector<Endianness, PolynomialType>(std::get<2>(filled_public_table.value()))

--- a/crypto3/libs/marshalling/zk/test/detail/circuits.hpp
+++ b/crypto3/libs/marshalling/zk/test/detail/circuits.hpp
@@ -177,8 +177,8 @@ namespace nil {
                         public_input_assignment[i] = table[witness_columns + i];
                     }
                     test_circuit.table = plonk_assignment_table<FieldType>(
-                        plonk_private_assignment_table<FieldType>(private_assignment),
-                        plonk_public_assignment_table<FieldType>(
+                        std::make_shared<plonk_private_assignment_table<FieldType>>(private_assignment),
+                        std::make_shared<plonk_public_assignment_table<FieldType>>(
                             public_input_assignment, constant_assignment, selectors_assignment));
 
                     test_circuit.table_rows = zk_padding<FieldType, plonk_column<FieldType>>(test_circuit.table, alg_rnd);
@@ -316,8 +316,8 @@ namespace nil {
                         public_input_assignment[i] = table[witness_columns + i];
                     }
                     test_circuit.table = plonk_assignment_table<FieldType>(
-                        plonk_private_assignment_table<FieldType>(private_assignment),
-                        plonk_public_assignment_table<FieldType>(
+                        std::make_shared<plonk_private_assignment_table<FieldType>>(private_assignment),
+                        std::make_shared<plonk_public_assignment_table<FieldType>>(
                             public_input_assignment, constant_assignment, selectors_assignment));
                     test_circuit.table_rows = zk_padding<FieldType, plonk_column<FieldType>>(test_circuit.table, alg_rnd);
 
@@ -414,8 +414,8 @@ namespace nil {
                         constant_assignment[i] = table[witness_columns + i];
                     }
                     test_circuit.table = plonk_assignment_table<FieldType>(
-                        plonk_private_assignment_table<FieldType>(private_assignment),
-                        plonk_public_assignment_table<FieldType>(
+                        std::make_shared<plonk_private_assignment_table<FieldType>>(private_assignment),
+                        std::make_shared<plonk_public_assignment_table<FieldType>>(
                             public_input_assignment, constant_assignment, selectors_assignment));
                     test_circuit.table_rows = zk_padding(test_circuit.table, alg_rnd);
 
@@ -521,8 +521,8 @@ namespace nil {
                         constant_assignment[i] = table[witness_columns + i];
                     }
                     test_circuit.table = plonk_assignment_table<FieldType>(
-                        plonk_private_assignment_table<FieldType>(private_assignment),
-                        plonk_public_assignment_table<FieldType>(
+                        std::make_shared<plonk_private_assignment_table<FieldType>>(private_assignment),
+                        std::make_shared<plonk_public_assignment_table<FieldType>>(
                             public_input_assignment, constant_assignment, selectors_assignment));
 
 
@@ -618,8 +618,8 @@ namespace nil {
                     selectors_assignment[0][1] = 1u;
 
                     test_circuit.table = plonk_assignment_table<FieldType>(
-                        plonk_private_assignment_table<FieldType>(private_assignment),
-                        plonk_public_assignment_table<FieldType>(
+                        std::make_shared<plonk_private_assignment_table<FieldType>>(private_assignment),
+                        std::make_shared<plonk_public_assignment_table<FieldType>>(
                             public_input_assignment, constant_assignment, selectors_assignment));
                     test_circuit.table_rows = zk_padding<FieldType, plonk_column<FieldType>>(test_circuit.table, alg_rnd);
 
@@ -714,8 +714,8 @@ namespace nil {
 
 
                     test_circuit.table = plonk_assignment_table<FieldType>(
-                        plonk_private_assignment_table<FieldType>(private_assignment),
-                        plonk_public_assignment_table<FieldType>(
+                        std::make_shared<plonk_private_assignment_table<FieldType>>(private_assignment),
+                        std::make_shared<plonk_public_assignment_table<FieldType>>(
                             public_input_assignment, constant_assignment, selectors_assignment));
                     test_circuit.table_rows = zk_padding<FieldType, plonk_column<FieldType>>(test_circuit.table, alg_rnd);
 
@@ -820,8 +820,8 @@ namespace nil {
                         constant_assignment[i] = table[witness_columns + selector_columns + i];
                     }
                     test_circuit.table = plonk_assignment_table<FieldType>(
-                        plonk_private_assignment_table<FieldType>(private_assignment),
-                        plonk_public_assignment_table<FieldType>(
+                        std::make_shared<plonk_private_assignment_table<FieldType>>(private_assignment),
+                        std::make_shared<plonk_public_assignment_table<FieldType>>(
                             public_input_assignment, constant_assignment, selectors_assignment));
                     test_circuit.table_rows = zk_padding(test_circuit.table, alg_rnd);
 
@@ -972,8 +972,8 @@ namespace nil {
                     std::vector<plonk_column<FieldType>> public_input_assignment(public_columns);
 
                     test_circuit.table = plonk_assignment_table<FieldType>(
-                        plonk_private_assignment_table<FieldType>(private_assignment),
-                        plonk_public_assignment_table<FieldType>(
+                        std::make_shared<plonk_private_assignment_table<FieldType>>(private_assignment),
+                        std::make_shared<plonk_public_assignment_table<FieldType>>(
                             public_input_assignment, constant_assignment, selectors_assignment));
                     test_circuit.table_rows = zk_padding(test_circuit.table, alg_rnd);
 
@@ -1128,8 +1128,8 @@ namespace nil {
                     }
 
                     test_circuit.table = plonk_assignment_table<FieldType>(
-                        plonk_private_assignment_table<FieldType>(private_assignment),
-                        plonk_public_assignment_table<FieldType>(
+                        std::make_shared<plonk_private_assignment_table<FieldType>>(private_assignment),
+                        std::make_shared<plonk_public_assignment_table<FieldType>>(
                             public_input_assignment,
                             constant_assignment,
                             selector_assignment

--- a/crypto3/libs/transpiler/test/detail/circuits.hpp
+++ b/crypto3/libs/transpiler/test/detail/circuits.hpp
@@ -178,8 +178,8 @@ namespace nil {
                         public_input_assignment[i] = table[witness_columns + i];
                     }
                     test_circuit.table = plonk_assignment_table<FieldType>(
-                        plonk_private_assignment_table<FieldType>(private_assignment),
-                        plonk_public_assignment_table<FieldType>(
+                        std::make_shared<plonk_private_assignment_table<FieldType>>(private_assignment),
+                        std::make_shared<plonk_public_assignment_table<FieldType>>(
                             public_input_assignment, constant_assignment, selectors_assignment));
 
                     test_circuit.table_rows = zk_padding<FieldType, plonk_column<FieldType>>(test_circuit.table, alg_rnd);
@@ -317,8 +317,8 @@ namespace nil {
                         public_input_assignment[i] = table[witness_columns + i];
                     }
                     test_circuit.table = plonk_assignment_table<FieldType>(
-                        plonk_private_assignment_table<FieldType>(private_assignment),
-                        plonk_public_assignment_table<FieldType>(
+                        std::make_shared<plonk_private_assignment_table<FieldType>>(private_assignment),
+                        std::make_shared<plonk_public_assignment_table<FieldType>>(
                             public_input_assignment, constant_assignment, selectors_assignment));
                     test_circuit.table_rows = zk_padding<FieldType, plonk_column<FieldType>>(test_circuit.table, alg_rnd);
 
@@ -415,8 +415,8 @@ namespace nil {
                         constant_assignment[i] = table[witness_columns + i];
                     }
                     test_circuit.table = plonk_assignment_table<FieldType>(
-                        plonk_private_assignment_table<FieldType>(private_assignment),
-                        plonk_public_assignment_table<FieldType>(
+                        std::make_shared<plonk_private_assignment_table<FieldType>>(private_assignment),
+                        std::make_shared<plonk_public_assignment_table<FieldType>>(
                             public_input_assignment, constant_assignment, selectors_assignment));
                     test_circuit.table_rows = zk_padding(test_circuit.table, alg_rnd);
 
@@ -521,8 +521,8 @@ namespace nil {
                         constant_assignment[i] = table[witness_columns + i];
                     }
                     test_circuit.table = plonk_assignment_table<FieldType>(
-                        plonk_private_assignment_table<FieldType>(private_assignment),
-                        plonk_public_assignment_table<FieldType>(
+                        std::make_shared<plonk_private_assignment_table<FieldType>>(private_assignment),
+                        std::make_shared<plonk_public_assignment_table<FieldType>>(
                             public_input_assignment, constant_assignment, selectors_assignment));
 
 
@@ -617,8 +617,8 @@ namespace nil {
                     selectors_assignment[0][1] = 1;
 
                     test_circuit.table = plonk_assignment_table<FieldType>(
-                        plonk_private_assignment_table<FieldType>(private_assignment),
-                        plonk_public_assignment_table<FieldType>(
+                        std::make_shared<plonk_private_assignment_table<FieldType>>(private_assignment),
+                        std::make_shared<plonk_public_assignment_table<FieldType>>(
                             public_input_assignment, constant_assignment, selectors_assignment));
                     test_circuit.table_rows = zk_padding<FieldType, plonk_column<FieldType>>(test_circuit.table, alg_rnd);
 
@@ -720,8 +720,8 @@ namespace nil {
 
 
                     test_circuit.table = plonk_assignment_table<FieldType>(
-                        plonk_private_assignment_table<FieldType>(private_assignment),
-                        plonk_public_assignment_table<FieldType>(
+                        std::make_shared<plonk_private_assignment_table<FieldType>>(private_assignment),
+                        std::make_shared<plonk_public_assignment_table<FieldType>>(
                             public_input_assignment, constant_assignment, selectors_assignment));
                     test_circuit.table_rows = zk_padding<FieldType, plonk_column<FieldType>>(test_circuit.table, alg_rnd);
 
@@ -826,8 +826,8 @@ namespace nil {
                         constant_assignment[i] = table[witness_columns + selector_columns + i];
                     }
                     test_circuit.table = plonk_assignment_table<FieldType>(
-                        plonk_private_assignment_table<FieldType>(private_assignment),
-                        plonk_public_assignment_table<FieldType>(
+                        std::make_shared<plonk_private_assignment_table<FieldType>>(private_assignment),
+                        std::make_shared<plonk_public_assignment_table<FieldType>>(
                             public_input_assignment, constant_assignment, selectors_assignment));
                     test_circuit.table_rows = zk_padding(test_circuit.table, alg_rnd);
 
@@ -977,8 +977,8 @@ namespace nil {
                     std::vector<plonk_column<FieldType>> public_input_assignment(public_columns);
 
                     test_circuit.table = plonk_assignment_table<FieldType>(
-                        plonk_private_assignment_table<FieldType>(private_assignment),
-                        plonk_public_assignment_table<FieldType>(
+                        std::make_shared<plonk_private_assignment_table<FieldType>>(private_assignment),
+                        std::make_shared<plonk_public_assignment_table<FieldType>>(
                             public_input_assignment, constant_assignment, selectors_assignment));
                     test_circuit.table_rows = zk_padding(test_circuit.table, alg_rnd);
 

--- a/crypto3/libs/zk/include/nil/crypto3/zk/commitments/polynomial/lpc.hpp
+++ b/crypto3/libs/zk/include/nil/crypto3/zk/commitments/polynomial/lpc.hpp
@@ -110,6 +110,7 @@ namespace nil {
                     {
                     }
 
+
                     lpc_commitment_scheme(const typename fri_type::params_type &fri_params)
                         : _fri_params(fri_params), _etha(0u) {
                     }

--- a/crypto3/libs/zk/include/nil/crypto3/zk/snark/arithmetization/plonk/assignment.hpp
+++ b/crypto3/libs/zk/include/nil/crypto3/zk/snark/arithmetization/plonk/assignment.hpp
@@ -29,6 +29,7 @@
 
 #include <algorithm>
 
+#include <memory>
 #include <nil/crypto3/zk/snark/arithmetization/plonk/padding.hpp>
 #include <nil/crypto3/random/algebraic_engine.hpp>
 #include <nil/crypto3/math/polynomial/shift.hpp>
@@ -123,10 +124,6 @@ namespace nil {
                         return _witnesses;
                     }
 
-                    witnesses_container_type move_witnesses() {
-                        return std::move(_witnesses);
-                    }
-
                     const ColumnType& operator[](std::uint32_t index) const {
                         if (index < _witnesses.size())
                             return _witnesses[index];
@@ -207,10 +204,6 @@ namespace nil {
                         return _public_inputs;
                     }
 
-                    public_input_container_type move_public_inputs() {
-                        return std::move(_public_inputs);
-                    }
-
                     std::uint32_t constants_amount() const {
                         return _constants.size();
                     }
@@ -232,10 +225,6 @@ namespace nil {
                         return _constants;
                     }
 
-                    constant_container_type move_constants() {
-                        return std::move(_constants);
-                    }
-
                     constexpr std::uint32_t selectors_amount() const {
                         return _selectors.size();
                     }
@@ -255,11 +244,6 @@ namespace nil {
 
                     const selector_container_type& selectors() const {
                         return _selectors;
-                    }
-
-                    selector_container_type move_selectors() {
-
-                        return std::move(_selectors);
                     }
 
                     void fill_constant(std::uint32_t index, const ColumnType& column) {
@@ -326,24 +310,29 @@ namespace nil {
 
                 protected:
                     // These are normally created by the assigner, or read from a file.
-                    private_table_type _private_table;
-                    public_table_type _public_table;
+                    std::shared_ptr<private_table_type> _private_table;
+                    std::shared_ptr<public_table_type> _public_table;
 
                 public:
                     virtual ~plonk_table() = default;
 
-                    plonk_table(private_table_type private_table = {},
-                                public_table_type public_table = {})
-                        : _private_table(std::move(private_table))
-                        , _public_table(std::move(public_table)) {
+                    plonk_table():
+                        _private_table(std::make_shared<plonk_private_table<FieldType, ColumnType>>()),
+                        _public_table(std::make_shared<plonk_public_table<FieldType, ColumnType>>()) {
+                    }
+
+                    plonk_table(std::shared_ptr<private_table_type> private_table,
+                                std::shared_ptr<public_table_type> public_table)
+                        : _private_table(private_table)
+                        , _public_table(public_table) {
                     }
 
                     plonk_table(std::size_t witnesses_amount,
                                 std::size_t public_inputs_amount,
                                 std::size_t constants_amount,
                                 std::size_t selectors_amount)
-                        : _private_table(witnesses_amount)
-                        , _public_table(public_inputs_amount, constants_amount, selectors_amount) {
+                        : _private_table(std::make_shared<private_table_type>(witnesses_amount))
+                        , _public_table(std::make_shared<public_table_type>(public_inputs_amount, constants_amount, selectors_amount)) {
                     }
 
                     crypto3::zk::snark::plonk_table_description<FieldType> get_description() const {
@@ -379,55 +368,55 @@ namespace nil {
                     }
 
                     const ColumnType& witness(std::uint32_t index) const {
-                        return _private_table.witness(index);
+                        return _private_table->witness(index);
                     }
 
                     typename field_type::value_type &witness(
                         std::uint32_t witness_index, std::uint32_t row_index) {
 
                         if (witness_column_size(witness_index) <= row_index)
-                            this->_private_table._witnesses[witness_index].resize(row_index + 1);
+                            this->_private_table->_witnesses[witness_index].resize(row_index + 1);
 
-                        return this->_private_table._witnesses[witness_index][row_index];
+                        return this->_private_table->_witnesses[witness_index][row_index];
                     }
 
                     const ColumnType& public_input(std::uint32_t index) const {
-                        return _public_table.public_input(index);
+                        return _public_table->public_input(index);
                     }
 
                     typename field_type::value_type &public_input(
                         std::uint32_t public_input_index, std::uint32_t row_index) {
 
                         if (public_input_column_size(public_input_index) <= row_index)
-                            this->_public_table._public_inputs[public_input_index].resize(row_index + 1);
+                            this->_public_table->_public_inputs[public_input_index].resize(row_index + 1);
 
-                        return this->_public_table._public_inputs[public_input_index][row_index];
+                        return this->_public_table->_public_inputs[public_input_index][row_index];
                     }
 
                     const ColumnType& constant(std::uint32_t index) const {
-                        return _public_table.constant(index);
+                        return _public_table->constant(index);
                     }
 
                     typename field_type::value_type &constant(
                         std::uint32_t constant_index, std::uint32_t row_index) {
 
                         if (constant_column_size(constant_index) <= row_index)
-                            this->_public_table._constants[constant_index].resize(row_index + 1);
+                            this->_public_table->_constants[constant_index].resize(row_index + 1);
 
-                        return this->_public_table._constants[constant_index][row_index];
+                        return this->_public_table->_constants[constant_index][row_index];
                     }
 
                     const ColumnType& selector(std::uint32_t index) const {
-                        return _public_table.selector(index);
+                        return _public_table->selector(index);
                     }
 
                     typename field_type::value_type &selector(
                         std::uint32_t selector_index, std::uint32_t row_index) {
 
                         if (selector_column_size(selector_index) <= row_index)
-                            this->_public_table._selectors[selector_index].resize(row_index + 1);
+                            this->_public_table->_selectors[selector_index].resize(row_index + 1);
 
-                        return this->_public_table._selectors[selector_index][row_index];
+                        return this->_public_table->_selectors[selector_index][row_index];
                     }
 
                     void enable_selector(const std::size_t selector_index, const std::size_t row_index) {
@@ -436,104 +425,104 @@ namespace nil {
                     }
 
                     virtual void fill_constant(std::uint32_t index, const ColumnType& column) {
-                        _public_table.fill_constant(index, column);
+                        _public_table->fill_constant(index, column);
                     }
 
                     virtual void fill_selector(std::uint32_t index, const ColumnType& column) {
-                        _public_table.fill_selector(index, column);
+                        _public_table->fill_selector(index, column);
                     }
 
                     const witnesses_container_type& witnesses() const {
-                        return _private_table.witnesses();
+                        return _private_table->witnesses();
                     }
 
                     const public_input_container_type& public_inputs() const {
-                        return _public_table.public_inputs();
+                        return _public_table->public_inputs();
                     }
 
                     const constant_container_type& constants() const {
-                        return _public_table.constants();
+                        return _public_table->constants();
                     }
 
                     const selector_container_type& selectors() const {
-                        return _public_table.selectors();
+                        return _public_table->selectors();
                     }
 
                     virtual void resize_witnesses(std::uint32_t new_size) {
-                        _private_table.resize_witnesses(new_size);
+                        _private_table->resize_witnesses(new_size);
                     }
 
                     virtual void resize_public_inputs(std::uint32_t new_size) {
-                        _public_table.resize_public_inputs(new_size);
+                        _public_table->resize_public_inputs(new_size);
                     }
 
                     virtual void resize_constants(std::uint32_t new_size) {
-                        _public_table.resize_constants(new_size);
+                        _public_table->resize_constants(new_size);
                     }
 
                     virtual void resize_selectors(std::uint32_t new_size) {
-                        _public_table.resize_selectors(new_size);
+                        _public_table->resize_selectors(new_size);
                     }
 
                     const ColumnType& operator[](std::uint32_t index) const {
-                        if (index < _private_table.size())
-                            return _private_table[index];
-                        index -= _private_table.size();
-                        if (index < _public_table.size())
-                            return _public_table[index];
+                        if (index < _private_table->size())
+                            return (*_private_table)[index];
+                        index -= _private_table->size();
+                        if (index < _public_table->size())
+                            return (*_public_table)[index];
                         throw std::out_of_range("Private table index out of range.");
                     }
 
-                    const private_table_type& private_table() const {
+                    std::shared_ptr<private_table_type> private_table() const {
                         return _private_table;
                     }
 
-                    private_table_type move_private_table() {
-                        return std::move(_private_table);
-                    }
-
-                    const public_table_type& public_table() const {
+                    std::shared_ptr<public_table_type> public_table() const {
                         return _public_table;
                     }
 
-                    public_table_type move_public_table() {
+                    std::shared_ptr<private_table_type> move_private_table() {
+                        return std::move(_private_table);
+                    }
+
+                    std::shared_ptr<public_table_type> move_public_table() {
                         return std::move(_public_table);
                     }
 
                     std::uint32_t size() const {
-                        return _private_table.size() + _public_table.size();
+                        return _private_table->size() + _public_table->size();
                     }
 
                     std::uint32_t witnesses_amount() const {
-                        return _private_table.witnesses_amount();
+                        return _private_table->witnesses_amount();
                     }
 
                     std::uint32_t witness_column_size(std::uint32_t index) const {
-                        return _private_table.witness_column_size(index);
+                        return _private_table->witness_column_size(index);
                     }
 
                     std::uint32_t public_inputs_amount() const {
-                        return _public_table.public_inputs_amount();
+                        return _public_table->public_inputs_amount();
                     }
 
                     std::uint32_t public_input_column_size(std::uint32_t index) const {
-                        return _public_table.public_input_column_size(index);
+                        return _public_table->public_input_column_size(index);
                     }
 
                     std::uint32_t constants_amount() const {
-                        return _public_table.constants_amount();
+                        return _public_table->constants_amount();
                     }
 
                     std::uint32_t constant_column_size(std::uint32_t index) const {
-                        return _public_table.constant_column_size(index);
+                        return _public_table->constant_column_size(index);
                     }
 
                     std::uint32_t selectors_amount() const {
-                        return _public_table.selectors_amount();
+                        return _public_table->selectors_amount();
                     }
 
                     std::uint32_t selector_column_size(std::uint32_t index) const {
-                        return _public_table.selector_column_size(index);
+                        return _public_table->selector_column_size(index);
                     }
 
                     std::uint32_t rows_amount() const {
@@ -563,7 +552,7 @@ namespace nil {
                     }
 
                     bool operator==(plonk_table<FieldType, ColumnType> const &other) const {
-                        return _private_table == other._private_table && _public_table == other._public_table;
+                        return *_private_table == *other._private_table && *_public_table == *other._public_table;
                     }
 
                     friend std::uint32_t basic_padding<FieldType, ColumnType>(

--- a/crypto3/libs/zk/include/nil/crypto3/zk/snark/arithmetization/plonk/detail/column_polynomial.hpp
+++ b/crypto3/libs/zk/include/nil/crypto3/zk/snark/arithmetization/plonk/detail/column_polynomial.hpp
@@ -91,7 +91,7 @@ namespace nil {
 
                     template<typename FieldType>
                     math::polynomial_dfs<typename FieldType::value_type>
-                        column_polynomial_dfs(plonk_column<FieldType> column_assignment,
+                        column_polynomial_dfs(const plonk_column<FieldType>& column_assignment,
                                               std::shared_ptr<math::evaluation_domain<FieldType>> domain) {
 
                         std::size_t d = std::distance(column_assignment.begin(), column_assignment.end()) - 1;
@@ -106,7 +106,7 @@ namespace nil {
 
                     template<typename FieldType>
                     std::vector<math::polynomial_dfs<typename FieldType::value_type>>
-                        column_range_polynomial_dfs(std::vector<plonk_column<FieldType>> column_range_assignment,
+                        column_range_polynomial_dfs(const std::vector<plonk_column<FieldType>>& column_range_assignment,
                                                     std::shared_ptr<math::evaluation_domain<FieldType>> domain) {
 
                         std::size_t columns_amount = column_range_assignment.size();
@@ -114,7 +114,7 @@ namespace nil {
 
                         for (std::size_t column_index = 0; column_index < columns_amount; column_index++) {
                             columns[column_index] =
-                                column_polynomial_dfs<FieldType>(std::move(column_range_assignment[column_index]), domain);
+                                column_polynomial_dfs<FieldType>(column_range_assignment[column_index], domain);
                         }
 
                         return columns;

--- a/crypto3/libs/zk/include/nil/crypto3/zk/snark/arithmetization/plonk/padding.hpp
+++ b/crypto3/libs/zk/include/nil/crypto3/zk/snark/arithmetization/plonk/padding.hpp
@@ -49,30 +49,30 @@ namespace nil {
                         padded_rows_amount = 8;
 
                     for (std::uint32_t w_index = 0; w_index <
-                                                   table._private_table.witnesses_amount(); w_index++) {
+                                                   table._private_table->witnesses_amount(); w_index++) {
 
-                        table._private_table._witnesses[w_index].resize(padded_rows_amount,
+                        table._private_table->_witnesses[w_index].resize(padded_rows_amount,
                                                                     FieldType::value_type::zero());
                     }
 
                     for (std::uint32_t pi_index = 0; pi_index <
-                                                   table._public_table.public_inputs_amount(); pi_index++) {
+                                                   table._public_table->public_inputs_amount(); pi_index++) {
 
-                        table._public_table._public_inputs[pi_index].resize(padded_rows_amount,
+                        table._public_table->_public_inputs[pi_index].resize(padded_rows_amount,
                                                                     FieldType::value_type::zero());
                     }
 
                     for (std::uint32_t c_index = 0; c_index <
-                                                  table._public_table.constants_amount(); c_index++) {
+                                                  table._public_table->constants_amount(); c_index++) {
 
-                        table._public_table._constants[c_index].resize(padded_rows_amount,
+                        table._public_table->_constants[c_index].resize(padded_rows_amount,
                                                                     FieldType::value_type::zero());
                     }
 
                     for (std::uint32_t s_index = 0; s_index <
-                                                  table._public_table.selectors_amount(); s_index++) {
+                                                  table._public_table->selectors_amount(); s_index++) {
 
-                        table._public_table._selectors[s_index].resize(padded_rows_amount,
+                        table._public_table->_selectors[s_index].resize(padded_rows_amount,
                                                                     FieldType::value_type::zero());
                     }
 
@@ -97,27 +97,27 @@ namespace nil {
                     //std::cout << "usable_rows_amount = " << usable_rows_amount << std::endl;
                     //std::cout << "padded_rows_amount = " << padded_rows_amount << std::endl;
 
-                    for (std::uint32_t w_index = 0; w_index < table._private_table.witnesses_amount(); w_index++) {
-                        table._private_table._witnesses[w_index].resize(usable_rows_amount, FieldType::value_type::zero());
+                    for (std::uint32_t w_index = 0; w_index < table._private_table->witnesses_amount(); w_index++) {
+                        table._private_table->_witnesses[w_index].resize(usable_rows_amount, FieldType::value_type::zero());
                     }
 
-                    for (std::uint32_t pi_index = 0; pi_index < table._public_table.public_inputs_amount(); pi_index++) {
-                        table._public_table._public_inputs[pi_index].resize(padded_rows_amount, FieldType::value_type::zero());
+                    for (std::uint32_t pi_index = 0; pi_index < table._public_table->public_inputs_amount(); pi_index++) {
+                        table._public_table->_public_inputs[pi_index].resize(padded_rows_amount, FieldType::value_type::zero());
                     }
 
-                    for (std::uint32_t c_index = 0; c_index < table._public_table.constants_amount(); c_index++) {
-                        table._public_table._constants[c_index].resize(padded_rows_amount, FieldType::value_type::zero());
+                    for (std::uint32_t c_index = 0; c_index < table._public_table->constants_amount(); c_index++) {
+                        table._public_table->_constants[c_index].resize(padded_rows_amount, FieldType::value_type::zero());
                     }
 
-                    for (std::uint32_t s_index = 0; s_index < table._public_table.selectors_amount(); s_index++) {
-                        table._public_table._selectors[s_index].resize(padded_rows_amount, FieldType::value_type::zero());
+                    for (std::uint32_t s_index = 0; s_index < table._public_table->selectors_amount(); s_index++) {
+                        table._public_table->_selectors[s_index].resize(padded_rows_amount, FieldType::value_type::zero());
                     }
 
 
-                    for (std::uint32_t w_index = 0; w_index < table._private_table.witnesses_amount(); w_index++) {
-                        table._private_table._witnesses[w_index].resize(padded_rows_amount);
+                    for (std::uint32_t w_index = 0; w_index < table._private_table->witnesses_amount(); w_index++) {
+                        table._private_table->_witnesses[w_index].resize(padded_rows_amount);
                         for(std::size_t i = usable_rows_amount; i < padded_rows_amount; i++) {
-                            table._private_table._witnesses[w_index][i] = alg_rnd();
+                            table._private_table->_witnesses[w_index][i] = alg_rnd();
                         }
                     }
                     return padded_rows_amount;

--- a/crypto3/libs/zk/include/nil/crypto3/zk/snark/systems/plonk/placeholder/gates_argument.hpp
+++ b/crypto3/libs/zk/include/nil/crypto3/zk/snark/systems/plonk/placeholder/gates_argument.hpp
@@ -77,7 +77,7 @@ namespace nil {
 
                     static inline void build_variable_value_map(
                         const math::expression<polynomial_dfs_variable_type>& expr,
-                        const plonk_polynomial_dfs_table<FieldType> &assignments,
+                        const plonk_polynomial_dfs_table<FieldType>& assignments,
                         std::shared_ptr<math::evaluation_domain<FieldType>> domain,
                         std::size_t extended_domain_size,
                         std::unordered_map<polynomial_dfs_variable_type, polynomial_dfs_type>& variable_values_out,
@@ -116,8 +116,7 @@ namespace nil {
 
                     static inline std::array<polynomial_dfs_type, argument_size> prove_eval(
                         const typename policy_type::constraint_system_type &constraint_system,
-                        const plonk_polynomial_dfs_table<FieldType>
-                            &column_polynomials,
+                        const plonk_polynomial_dfs_table<FieldType>& column_polynomials,
                         std::shared_ptr<math::evaluation_domain<FieldType>> original_domain,
                         std::uint32_t max_gates_degree,
                         const polynomial_dfs_type &mask_polynomial,

--- a/crypto3/libs/zk/include/nil/crypto3/zk/snark/systems/plonk/placeholder/lookup_argument.hpp
+++ b/crypto3/libs/zk/include/nil/crypto3/zk/snark/systems/plonk/placeholder/lookup_argument.hpp
@@ -47,8 +47,10 @@
 #include <nil/crypto3/zk/snark/systems/plonk/placeholder/params.hpp>
 #include <nil/crypto3/zk/snark/systems/plonk/placeholder/detail/placeholder_policy.hpp>
 #include <nil/crypto3/zk/snark/systems/plonk/placeholder/preprocessor.hpp>
+#include <nil/crypto3/zk/snark/arithmetization/plonk/assignment.hpp>
 
 #include <nil/crypto3/bench/scoped_profiler.hpp>
+
 
 namespace nil {
     namespace crypto3 {
@@ -134,8 +136,7 @@ namespace nil {
                                 &constraint_system,
                             const typename placeholder_public_preprocessor<FieldType, ParamsType>::preprocessed_data_type
                                 &preprocessed_data,
-                            const plonk_polynomial_dfs_table<FieldType>
-                                &plonk_columns,
+                            const plonk_polynomial_dfs_table<FieldType>& plonk_columns,
                             commitment_scheme_type &commitment_scheme,
                             transcript_type &transcript)
                         : constraint_system(constraint_system)
@@ -655,7 +656,7 @@ namespace nil {
 
                     const plonk_constraint_system<FieldType> &constraint_system;
                     const typename placeholder_public_preprocessor<FieldType, ParamsType>::preprocessed_data_type& preprocessed_data;
-                    const plonk_polynomial_dfs_table<FieldType> &plonk_columns;
+                    const plonk_polynomial_dfs_table<FieldType>& plonk_columns;
                     commitment_scheme_type& commitment_scheme;
                     transcript_type& transcript;
                     std::shared_ptr<math::evaluation_domain<FieldType>> basic_domain;

--- a/crypto3/libs/zk/include/nil/crypto3/zk/snark/systems/plonk/placeholder/permutation_argument.hpp
+++ b/crypto3/libs/zk/include/nil/crypto3/zk/snark/systems/plonk/placeholder/permutation_argument.hpp
@@ -43,6 +43,7 @@
 #include <nil/crypto3/zk/snark/systems/plonk/placeholder/params.hpp>
 #include <nil/crypto3/zk/snark/systems/plonk/placeholder/detail/placeholder_policy.hpp>
 #include <nil/crypto3/zk/snark/systems/plonk/placeholder/preprocessor.hpp>
+#include <nil/crypto3/zk/snark/arithmetization/plonk/assignment.hpp>
 
 #include <nil/crypto3/bench/scoped_profiler.hpp>
 
@@ -73,7 +74,7 @@ namespace nil {
                         const typename placeholder_public_preprocessor<FieldType, ParamsType>::preprocessed_data_type
                             preprocessed_data,
                         const plonk_table_description<FieldType> &table_description,
-                        const plonk_polynomial_dfs_table<FieldType> &column_polynomials,
+                        const plonk_polynomial_dfs_table<FieldType>& column_polynomials,
                         typename ParamsType::commitment_scheme_type& commitment_scheme,
                         transcript_type& transcript
                     ) {

--- a/crypto3/libs/zk/include/nil/crypto3/zk/snark/systems/plonk/placeholder/preprocessor.hpp
+++ b/crypto3/libs/zk/include/nil/crypto3/zk/snark/systems/plonk/placeholder/preprocessor.hpp
@@ -76,6 +76,7 @@ namespace nil {
                     using commitment_type = typename commitment_scheme_type::commitment_type;
                     using transcript_type = typename commitment_scheme_type::transcript_type;
                     using transcript_hash_type = typename commitment_scheme_type::transcript_hash_type;
+                    using public_assignment_type = typename policy_type::variable_assignment_type::public_table_type;
 
                 public:
                     static std::size_t permutation_partitions_num(
@@ -264,7 +265,7 @@ namespace nil {
                         };
 
                         bool operator==(const preprocessed_data_type &rhs) const {
-                            return public_polynomial_table == rhs.public_polynomial_table &&
+                            return shared_ptr_equal(public_polynomial_table, rhs.public_polynomial_table) &&
                                 permutation_polynomials == rhs.permutation_polynomials &&
                                 identity_polynomials == rhs.identity_polynomials &&
                                 q_last == rhs.q_last &&
@@ -276,7 +277,7 @@ namespace nil {
                             return !(rhs == *this);
                         }
 
-                        plonk_public_polynomial_dfs_table_type public_polynomial_table;
+                        std::shared_ptr<plonk_public_polynomial_dfs_table_type> public_polynomial_table;
 
                         // S_sigma
                         std::vector<polynomial_dfs_type>  permutation_polynomials;
@@ -287,6 +288,19 @@ namespace nil {
                         polynomial_dfs_type q_blind;
 
                         common_data_type common_data;
+
+                    private:
+                        template<typename T>
+                        static bool shared_ptr_equal(const std::shared_ptr<T> &lhs, const std::shared_ptr<T> &rhs) {
+                            bool both_null = (lhs == nullptr && rhs == nullptr);
+                            if (both_null) {
+                                return true;
+                            }
+                            if (lhs == nullptr || rhs == nullptr) {
+                                return false;
+                            }
+                            return *lhs == *rhs;
+                        }
                     };
 
                 private:
@@ -383,6 +397,18 @@ namespace nil {
                             return _mapping[key];
                         }
                     };
+
+                    static inline std::shared_ptr<plonk_public_polynomial_dfs_table<FieldType>> convert_public_table(
+                        std::shared_ptr<public_assignment_type> public_assignment,
+                        std::shared_ptr<math::evaluation_domain<FieldType>> basic_domain
+                    ) {
+                        return std::make_shared<plonk_public_polynomial_dfs_table<FieldType>>(    
+                            detail::column_range_polynomial_dfs<FieldType>(public_assignment->public_inputs(), basic_domain),
+                            detail::column_range_polynomial_dfs<FieldType>(public_assignment->constants(), basic_domain),
+                            detail::column_range_polynomial_dfs<FieldType>(public_assignment->selectors(), basic_domain)
+                        );
+                    }
+
 
                 public:
                     static inline std::vector<std::set<int>>
@@ -535,7 +561,7 @@ namespace nil {
                     // TODO: columns_with_copy_constraints -- It should be extracted from constraint_system
                     static inline preprocessed_data_type process(
                         const plonk_constraint_system<FieldType> &constraint_system,
-                        typename policy_type::variable_assignment_type::public_table_type public_assignment,
+                        std::shared_ptr<public_assignment_type> public_assignment,
                         const plonk_table_description<FieldType>
                             &table_description,
                         typename ParamsType::commitment_scheme_type &commitment_scheme,
@@ -580,15 +606,7 @@ namespace nil {
                         q_last_q_blind[0] = lagrange_polynomial(basic_domain, usable_rows);
                         q_last_q_blind[1] = selector_blind(usable_rows, basic_domain);
 
-                        plonk_public_polynomial_dfs_table<FieldType>
-                            public_polynomial_table =
-                                plonk_public_polynomial_dfs_table<FieldType>(
-                                    detail::column_range_polynomial_dfs<FieldType>(public_assignment.move_public_inputs(),
-                                                                                   basic_domain),
-                                    detail::column_range_polynomial_dfs<FieldType>(public_assignment.move_constants(),
-                                                                                   basic_domain),
-                                    detail::column_range_polynomial_dfs<FieldType>(public_assignment.move_selectors(),
-                                                                                   basic_domain));
+                        auto public_polynomial_table = convert_public_table(std::move(public_assignment), basic_domain);
 
                         // prepare commitments for short verifier
                         //typename preprocessed_data_type::public_precommitments_type public_precommitments =
@@ -600,7 +618,7 @@ namespace nil {
                         std::size_t lookup_parts_num = constraint_system.lookup_parts(max_quotient_poly_chunks).size();
 
                         typename preprocessed_data_type::public_commitments_type public_commitments = commitments(
-                            public_polynomial_table, id_perm_polys,
+                            *public_polynomial_table, id_perm_polys,
                             sigma_perm_polys, q_last_q_blind, commitment_scheme
                         );
 
@@ -658,12 +676,14 @@ namespace nil {
                     struct preprocessed_data_type {
                         std::shared_ptr<math::evaluation_domain<FieldType>> basic_domain;
 
-                        plonk_private_polynomial_dfs_table<FieldType> private_polynomial_table;
+                        std::shared_ptr<plonk_private_polynomial_dfs_table<FieldType>> private_polynomial_table;
                     };
+
+                    using private_assignment_type = typename policy_type::variable_assignment_type::private_table_type;
 
                     static inline preprocessed_data_type process(
                         const plonk_constraint_system<FieldType>  &constraint_system,
-                        typename policy_type::variable_assignment_type::private_table_type private_assignment,
+                        std::shared_ptr<private_assignment_type> private_assignment,
                         const plonk_table_description<FieldType>  &table_description
                     ) {
                         std::size_t N_rows = table_description.rows_amount;
@@ -671,10 +691,13 @@ namespace nil {
                         std::shared_ptr<math::evaluation_domain<FieldType>> basic_domain =
                             math::make_evaluation_domain<FieldType>(N_rows);
 
-                        plonk_private_polynomial_dfs_table<FieldType>
-                            private_polynomial_table(detail::column_range_polynomial_dfs<FieldType>(
-                                private_assignment.move_witnesses(), basic_domain));
-                        return preprocessed_data_type({basic_domain, std::move(private_polynomial_table)});
+                        auto private_polynomial_table = std::make_shared<plonk_private_polynomial_dfs_table<FieldType>>(
+                            detail::column_range_polynomial_dfs<FieldType>(
+                                private_assignment->witnesses(),
+                                basic_domain
+                            )
+                        );
+                        return preprocessed_data_type({basic_domain, private_polynomial_table});
                     }
                 };
             }    // namespace snark

--- a/crypto3/libs/zk/include/nil/crypto3/zk/snark/systems/plonk/placeholder/prover.hpp
+++ b/crypto3/libs/zk/include/nil/crypto3/zk/snark/systems/plonk/placeholder/prover.hpp
@@ -97,33 +97,33 @@ namespace nil {
                         typename private_preprocessor_type::preprocessed_data_type preprocessed_private_data,
                         const plonk_table_description<FieldType> &table_description,
                         const plonk_constraint_system<FieldType> &constraint_system,
-                        const commitment_scheme_type& commitment_scheme,
+                        commitment_scheme_type commitment_scheme,
                         bool skip_commitment_scheme_eval_proofs = false
                     ) {
                         auto prover = placeholder_prover<FieldType, ParamsType>(
                             preprocessed_public_data, std::move(preprocessed_private_data), table_description,
-                            constraint_system, commitment_scheme, skip_commitment_scheme_eval_proofs);
+                            constraint_system, std::move(commitment_scheme), skip_commitment_scheme_eval_proofs);
                         return prover.process();
                     }
 
                     placeholder_prover(
                         const typename public_preprocessor_type::preprocessed_data_type &preprocessed_public_data,
-                        typename private_preprocessor_type::preprocessed_data_type preprocessed_private_data,
+                        const typename private_preprocessor_type::preprocessed_data_type &preprocessed_private_data,
                         const plonk_table_description<FieldType> &table_description,
                         const plonk_constraint_system<FieldType> &constraint_system,
-                        const commitment_scheme_type &commitment_scheme,
+                        commitment_scheme_type commitment_scheme,
                         bool skip_commitment_scheme_eval_proofs = false
                     )
                             : preprocessed_public_data(preprocessed_public_data)
                             , table_description(table_description)
                             , constraint_system(constraint_system)
-                            , _polynomial_table(new plonk_polynomial_dfs_table<FieldType>(
-                                std::move(preprocessed_private_data.private_polynomial_table),
-                                preprocessed_public_data.public_polynomial_table))
-
+                            , _polynomial_table(std::make_unique<plonk_polynomial_dfs_table<FieldType>>(
+                                preprocessed_private_data.private_polynomial_table,
+                                preprocessed_public_data.public_polynomial_table
+                            ))
                             , transcript(std::vector<std::uint8_t>({}))
                             , _is_lookup_enabled(constraint_system.lookup_gates().size() > 0)
-                            , _commitment_scheme(commitment_scheme)
+                            , _commitment_scheme(std::move(commitment_scheme))
                             , _skip_commitment_scheme_eval_proofs(skip_commitment_scheme_eval_proofs)
                     {
                         // Initialize transcript.
@@ -145,7 +145,7 @@ namespace nil {
                             _proof.commitments[VARIABLE_VALUES_BATCH] = _commitment_scheme.commit(VARIABLE_VALUES_BATCH);
                         }
                         transcript(_proof.commitments[VARIABLE_VALUES_BATCH]);
-
+                        
                         // 4. permutation_argument
                         if( constraint_system.copy_constraints().size() > 0 ){
                             auto permutation_argument = placeholder_permutation_argument<FieldType, ParamsType>::prove_eval(
@@ -192,12 +192,12 @@ namespace nil {
                             transcript
                         )[0];
 
+                        _polynomial_table.reset(); // not needed anymore, release memory
+
                         /////TEST
 #ifdef ZK_PLACEHOLDER_DEBUG_ENABLED
                         placeholder_debug_output();
 #endif
-                        // _polynomial_table not needed, clean its memory
-                        _polynomial_table.reset(nullptr);
 
                         // 7. Aggregate quotient polynomial
                         {
@@ -227,6 +227,10 @@ namespace nil {
 
                     commitment_scheme_type& get_commitment_scheme() {
                         return _commitment_scheme;
+                    }
+
+                    commitment_scheme_type move_commitment_scheme() {
+                        return std::move(_commitment_scheme);
                     }
 
                 private:
@@ -318,7 +322,7 @@ namespace nil {
                                 _commitment_scheme,
                                 transcript
                             );
-;
+
                             lookup_argument_result = lookup_argument_prover.prove_eval();
                             _proof.commitments[LOOKUP_BATCH] = lookup_argument_result.lookup_commitment;
                         }
@@ -346,7 +350,7 @@ namespace nil {
                             for (std::size_t j = 0; j < gates[i].constraints.size(); j++) {
                                 polynomial_dfs_type constraint_result =
                                     gates[i].constraints[j].evaluate(
-                                        *_polynomial_table, preprocessed_public_data.common_data.basic_domain) *
+                                        _polynomial_table, preprocessed_public_data.common_data.basic_domain) *
                                     _polynomial_table.selector(gates[i].selector_index);
                                 // for (std::size_t k = 0; k < table_description.rows_amount; k++) {
                                 if (constraint_result.evaluate(
@@ -414,7 +418,7 @@ namespace nil {
                         _commitment_scheme.append_eval_point(FIXED_VALUES_BATCH, start_index - 1, _proof.eval_proof.challenge * _omega);
 
                         for (std::size_t ind = 0;
-                            ind < constant_columns + preprocessed_public_data.public_polynomial_table.selectors().size();
+                            ind < constant_columns + preprocessed_public_data.public_polynomial_table->selectors().size();
                             ind++, i++
                         ) {
                             const std::set<int>& fixed_values_rotation =

--- a/crypto3/libs/zk/include/nil/crypto3/zk/snark/systems/plonk/placeholder/verifier.hpp
+++ b/crypto3/libs/zk/include/nil/crypto3/zk/snark/systems/plonk/placeholder/verifier.hpp
@@ -150,7 +150,7 @@ namespace nil {
                         const placeholder_proof<FieldType, ParamsType> &proof,
                         const plonk_table_description<FieldType> &table_description,
                         const plonk_constraint_system<FieldType> &constraint_system,
-                        commitment_scheme_type commitment_scheme,
+                        commitment_scheme_type& commitment_scheme,
                         const std::vector<std::vector<typename FieldType::value_type>> &public_input
                     ){
                         // TODO: process rotations for public input.
@@ -191,7 +191,7 @@ namespace nil {
                         const placeholder_proof<FieldType, ParamsType> &proof,
                         const plonk_table_description<FieldType> &table_description,
                         const plonk_constraint_system<FieldType> &constraint_system,
-                        commitment_scheme_type commitment_scheme
+                        commitment_scheme_type& commitment_scheme
                     ) {
 
                         // We cannot add eval points unless everything is committed, so when verifying assume it's committed.

--- a/crypto3/libs/zk/test/systems/plonk/placeholder/circuits.hpp
+++ b/crypto3/libs/zk/test/systems/plonk/placeholder/circuits.hpp
@@ -29,6 +29,7 @@
 #ifndef CRYPTO3_ZK_TEST_PLONK_CIRCUITS_HPP
 #define CRYPTO3_ZK_TEST_PLONK_CIRCUITS_HPP
 
+#include <memory>
 #define _RND_ algebra::random_element<FieldType>();
 
 #include <nil/crypto3/algebra/random_element.hpp>
@@ -177,8 +178,8 @@ namespace nil {
                         public_input_assignment[i] = table[witness_columns + i];
                     }
                     test_circuit.table = plonk_assignment_table<FieldType>(
-                        plonk_private_assignment_table<FieldType>(private_assignment),
-                        plonk_public_assignment_table<FieldType>(
+                        std::make_shared<plonk_private_assignment_table<FieldType>>(private_assignment),
+                        std::make_shared<plonk_public_assignment_table<FieldType>>(
                             public_input_assignment, constant_assignment, selectors_assignment));
 
                     test_circuit.table_rows = zk_padding<FieldType, plonk_column<FieldType>>(test_circuit.table, alg_rnd);
@@ -316,8 +317,8 @@ namespace nil {
                         public_input_assignment[i] = table[witness_columns + i];
                     }
                     test_circuit.table = plonk_assignment_table<FieldType>(
-                        plonk_private_assignment_table<FieldType>(private_assignment),
-                        plonk_public_assignment_table<FieldType>(
+                        std::make_shared<plonk_private_assignment_table<FieldType>>(private_assignment),
+                        std::make_shared<plonk_public_assignment_table<FieldType>>(
                             public_input_assignment, constant_assignment, selectors_assignment));
                     test_circuit.table_rows = zk_padding<FieldType, plonk_column<FieldType>>(test_circuit.table, alg_rnd);
 
@@ -414,8 +415,8 @@ namespace nil {
                         constant_assignment[i] = table[witness_columns + i];
                     }
                     test_circuit.table = plonk_assignment_table<FieldType>(
-                        plonk_private_assignment_table<FieldType>(private_assignment),
-                        plonk_public_assignment_table<FieldType>(
+                        std::make_shared<plonk_private_assignment_table<FieldType>>(private_assignment),
+                        std::make_shared<plonk_public_assignment_table<FieldType>>(
                             public_input_assignment, constant_assignment, selectors_assignment));
                     test_circuit.table_rows = zk_padding(test_circuit.table, alg_rnd);
 
@@ -521,8 +522,8 @@ namespace nil {
                         constant_assignment[i] = table[witness_columns + i];
                     }
                     test_circuit.table = plonk_assignment_table<FieldType>(
-                        plonk_private_assignment_table<FieldType>(private_assignment),
-                        plonk_public_assignment_table<FieldType>(
+                        std::make_shared<plonk_private_assignment_table<FieldType>>(private_assignment),
+                        std::make_shared<plonk_public_assignment_table<FieldType>>(
                             public_input_assignment, constant_assignment, selectors_assignment));
 
 
@@ -618,8 +619,8 @@ namespace nil {
                     selectors_assignment[0][1] = 1u;
 
                     test_circuit.table = plonk_assignment_table<FieldType>(
-                        plonk_private_assignment_table<FieldType>(private_assignment),
-                        plonk_public_assignment_table<FieldType>(
+                        std::make_shared<plonk_private_assignment_table<FieldType>>(private_assignment),
+                        std::make_shared<plonk_public_assignment_table<FieldType>>(
                             public_input_assignment, constant_assignment, selectors_assignment));
                     test_circuit.table_rows = zk_padding<FieldType, plonk_column<FieldType>>(test_circuit.table, alg_rnd);
 
@@ -714,8 +715,8 @@ namespace nil {
 
 
                     test_circuit.table = plonk_assignment_table<FieldType>(
-                        plonk_private_assignment_table<FieldType>(private_assignment),
-                        plonk_public_assignment_table<FieldType>(
+                        std::make_shared<plonk_private_assignment_table<FieldType>>(private_assignment),
+                        std::make_shared<plonk_public_assignment_table<FieldType>>(
                             public_input_assignment, constant_assignment, selectors_assignment));
                     test_circuit.table_rows = zk_padding<FieldType, plonk_column<FieldType>>(test_circuit.table, alg_rnd);
 
@@ -820,8 +821,8 @@ namespace nil {
                         constant_assignment[i] = table[witness_columns + selector_columns + i];
                     }
                     test_circuit.table = plonk_assignment_table<FieldType>(
-                        plonk_private_assignment_table<FieldType>(private_assignment),
-                        plonk_public_assignment_table<FieldType>(
+                        std::make_shared<plonk_private_assignment_table<FieldType>>(private_assignment),
+                        std::make_shared<plonk_public_assignment_table<FieldType>>(
                             public_input_assignment, constant_assignment, selectors_assignment));
                     test_circuit.table_rows = zk_padding(test_circuit.table, alg_rnd);
 
@@ -972,8 +973,8 @@ namespace nil {
                     std::vector<plonk_column<FieldType>> public_input_assignment(public_columns);
 
                     test_circuit.table = plonk_assignment_table<FieldType>(
-                        plonk_private_assignment_table<FieldType>(private_assignment),
-                        plonk_public_assignment_table<FieldType>(
+                        std::make_shared<plonk_private_assignment_table<FieldType>>(private_assignment),
+                        std::make_shared<plonk_public_assignment_table<FieldType>>(
                             public_input_assignment, constant_assignment, selectors_assignment));
                     test_circuit.table_rows = zk_padding(test_circuit.table, alg_rnd);
 
@@ -1128,8 +1129,8 @@ namespace nil {
                     }
 
                     test_circuit.table = plonk_assignment_table<FieldType>(
-                        plonk_private_assignment_table<FieldType>(private_assignment),
-                        plonk_public_assignment_table<FieldType>(
+                        std::make_shared<plonk_private_assignment_table<FieldType>>(private_assignment),
+                        std::make_shared<plonk_public_assignment_table<FieldType>>(
                             public_input_assignment,
                             constant_assignment,
                             selector_assignment

--- a/crypto3/libs/zk/test/systems/plonk/placeholder/placeholder_permutation_argument.cpp
+++ b/crypto3/libs/zk/test/systems/plonk/placeholder/placeholder_permutation_argument.cpp
@@ -130,12 +130,12 @@ BOOST_AUTO_TEST_SUITE(permutation_argument)
 
         typename placeholder_public_preprocessor<field_type, lpc_placeholder_params_type>::preprocessed_data_type
                 lpc_preprocessed_public_data = placeholder_public_preprocessor<field_type, lpc_placeholder_params_type>::process(
-                constraint_system, assignments.move_public_table(), desc, lpc_scheme
+                constraint_system, assignments.public_table(), desc, lpc_scheme
         );
 
         typename placeholder_private_preprocessor<field_type, lpc_placeholder_params_type>::preprocessed_data_type
                 lpc_preprocessed_private_data = placeholder_private_preprocessor<field_type, lpc_placeholder_params_type>::process(
-                constraint_system, assignments.move_private_table(), desc
+                constraint_system, assignments.private_table(), desc
         );
 
         auto polynomial_table =
@@ -237,12 +237,12 @@ BOOST_AUTO_TEST_SUITE(permutation_argument)
 
         typename placeholder_public_preprocessor<field_type, lpc_placeholder_params_type>::preprocessed_data_type
                 preprocessed_public_data = placeholder_public_preprocessor<field_type, lpc_placeholder_params_type>::process(
-                constraint_system, assignments.move_public_table(), desc, lpc_scheme
+                constraint_system, assignments.public_table(), desc, lpc_scheme
         );
 
         typename placeholder_private_preprocessor<field_type, lpc_placeholder_params_type>::preprocessed_data_type
                 preprocessed_private_data = placeholder_private_preprocessor<field_type, lpc_placeholder_params_type>::process(
-                constraint_system, assignments.move_private_table(), desc
+                constraint_system, assignments.private_table(), desc
         );
 
         auto polynomial_table =

--- a/crypto3/libs/zk/test/systems/plonk/placeholder/placeholder_test_runner.hpp
+++ b/crypto3/libs/zk/test/systems/plonk/placeholder/placeholder_test_runner.hpp
@@ -94,11 +94,11 @@ struct placeholder_test_runner {
 
         typename placeholder_public_preprocessor<field_type, lpc_placeholder_params_type>::preprocessed_data_type
                 lpc_preprocessed_public_data = placeholder_public_preprocessor<field_type, lpc_placeholder_params_type>::process(
-                constraint_system, assignments.move_public_table(), desc, lpc_scheme, max_quotient_poly_chunks);
+                constraint_system, assignments.public_table(), desc, lpc_scheme, max_quotient_poly_chunks);
 
         typename placeholder_private_preprocessor<field_type, lpc_placeholder_params_type>::preprocessed_data_type
                 lpc_preprocessed_private_data = placeholder_private_preprocessor<field_type, lpc_placeholder_params_type>::process(
-                constraint_system, assignments.move_private_table(), desc);
+                constraint_system, assignments.private_table(), desc);
 
         auto lpc_proof = placeholder_prover<field_type, lpc_placeholder_params_type>::process(
                 lpc_preprocessed_public_data, std::move(lpc_preprocessed_private_data), desc, constraint_system,

--- a/crypto3/libs/zk/test/systems/plonk/plonk_constraint.cpp
+++ b/crypto3/libs/zk/test/systems/plonk/plonk_constraint.cpp
@@ -24,6 +24,7 @@
 // SOFTWARE.
 //---------------------------------------------------------------------------//
 
+#include <memory>
 #define BOOST_TEST_MODULE plonk_constraint_test
 
 #include <string>
@@ -79,9 +80,15 @@ BOOST_AUTO_TEST_CASE(plonk_constraint_basic_test) {
     std::cout << witness_columns[1][0].data << std::endl;
     std::cout << witness_columns[2][0].data << std::endl;
 
-    zk::snark::plonk_private_assignment_table<FieldType> private_assignment(witness_columns);
+    using public_table = zk::snark::plonk_public_assignment_table<FieldType>;
+    using private_table = zk::snark::plonk_private_assignment_table<FieldType>;
 
-    zk::snark::plonk_assignment_table<FieldType> assignment(private_assignment);
+    auto private_assignment = std::make_shared<private_table>(witness_columns);
+
+    zk::snark::plonk_assignment_table<FieldType> assignment(
+        private_assignment, 
+        std::make_shared<public_table>()
+    );
 
     BOOST_CHECK((witness_columns[0][0] + witness_columns[1][0] - witness_columns[2][0]) ==
                 constraint.evaluate(0, assignment));

--- a/parallel-crypto3/libs/parallel-zk/include/nil/crypto3/zk/commitments/polynomial/lpc.hpp
+++ b/parallel-crypto3/libs/parallel-zk/include/nil/crypto3/zk/commitments/polynomial/lpc.hpp
@@ -111,7 +111,8 @@ namespace nil {
                         , _fixed_polys_values(fixed_polys_values)
                     {
                     }
-
+ 
+      
                     lpc_commitment_scheme(const typename fri_type::params_type &fri_params)
                         : _fri_params(fri_params), _etha(0u) {
                     }

--- a/parallel-crypto3/libs/parallel-zk/include/nil/crypto3/zk/snark/arithmetization/plonk/assignment.hpp
+++ b/parallel-crypto3/libs/parallel-zk/include/nil/crypto3/zk/snark/arithmetization/plonk/assignment.hpp
@@ -29,10 +29,13 @@
 
 #include <algorithm>
 
+#include <memory>
 #include <nil/crypto3/zk/snark/arithmetization/plonk/padding.hpp>
 #include <nil/crypto3/random/algebraic_engine.hpp>
+#include <nil/crypto3/math/polynomial/shift.hpp>
 #include <nil/crypto3/math/polynomial/polynomial_dfs.hpp>
 #include <nil/crypto3/zk/snark/arithmetization/plonk/variable.hpp>
+#include <nil/crypto3/zk/snark/arithmetization/plonk/table_description.hpp>
 
 namespace nil {
     namespace blueprint {
@@ -102,7 +105,8 @@ namespace nil {
                         }
                     }
 
-                    ColumnType get_variable_value(const VariableType& var, std::shared_ptr<math::evaluation_domain<FieldType>> domain) const {
+                    ColumnType get_variable_value(const VariableType& var,
+                            std::shared_ptr<math::evaluation_domain<FieldType>> domain) const {
                          if (var.rotation == 0) {
                              return get_variable_value_without_rotation(var);
                          }
@@ -118,10 +122,6 @@ namespace nil {
 
                     const witnesses_container_type& witnesses() const {
                         return _witnesses;
-                    }
-
-                    witnesses_container_type move_witnesses() {
-                        return std::move(_witnesses);
                     }
 
                     const ColumnType& operator[](std::uint32_t index) const {
@@ -254,11 +254,6 @@ namespace nil {
                         return _selectors;
                     }
 
-                    selector_container_type move_selectors() {
-
-                        return std::move(_selectors);
-                    }
-
                     void fill_constant(std::uint32_t index, const ColumnType& column) {
                         BOOST_ASSERT(index < constants_amount());
                         BOOST_ASSERT(_constants[index].size() == 0);
@@ -323,24 +318,35 @@ namespace nil {
 
                 protected:
                     // These are normally created by the assigner, or read from a file.
-                    private_table_type _private_table;
-                    public_table_type _public_table;
+                    std::shared_ptr<private_table_type> _private_table;
+                    std::shared_ptr<public_table_type> _public_table;
 
                 public:
                     virtual ~plonk_table() = default;
 
-                    plonk_table(private_table_type private_table = {},
-                                public_table_type public_table = {})
-                        : _private_table(std::move(private_table))
-                        , _public_table(std::move(public_table)) {
+                    plonk_table():
+                        _private_table(std::make_shared<plonk_private_table<FieldType, ColumnType>>()),
+                        _public_table(std::make_shared<plonk_public_table<FieldType, ColumnType>>()) {
+                    }
+
+                    plonk_table(std::shared_ptr<private_table_type> private_table,
+                                std::shared_ptr<public_table_type> public_table)
+                        : _private_table(private_table)
+                        , _public_table(public_table) {
                     }
 
                     plonk_table(std::size_t witnesses_amount,
                                 std::size_t public_inputs_amount,
                                 std::size_t constants_amount,
                                 std::size_t selectors_amount)
-                        : _private_table(witnesses_amount)
-                        , _public_table(public_inputs_amount, constants_amount, selectors_amount) {
+                        : _private_table(std::make_shared<private_table_type>(witnesses_amount))
+                        , _public_table(std::make_shared<public_table_type>(public_inputs_amount, constants_amount, selectors_amount)) {
+                    }
+
+                    crypto3::zk::snark::plonk_table_description<FieldType> get_description() const {
+                        return crypto3::zk::snark::plonk_table_description<FieldType>(
+                            witnesses_amount(), public_inputs_amount(), constants_amount(), selectors_amount(),
+                            rows_amount(), std::pow(2, std::ceil(std::log2(rows_amount()))));
                     }
 
                     template <typename InputVariableType>
@@ -370,56 +376,55 @@ namespace nil {
                     }
 
                     const ColumnType& witness(std::uint32_t index) const {
-                        return _private_table.witness(index);
+                        return _private_table->witness(index);
                     }
 
                     typename field_type::value_type &witness(
                         std::uint32_t witness_index, std::uint32_t row_index) {
 
                         if (witness_column_size(witness_index) <= row_index)
-                            this->_private_table._witnesses[witness_index].resize(row_index + 1);
+                            this->_private_table->_witnesses[witness_index].resize(row_index + 1);
 
-                        return this->_private_table._witnesses[witness_index][row_index];
+                        return this->_private_table->_witnesses[witness_index][row_index];
                     }
 
                     const ColumnType& public_input(std::uint32_t index) const {
-                        return _public_table.public_input(index);
+                        return _public_table->public_input(index);
                     }
 
                     typename field_type::value_type &public_input(
                         std::uint32_t public_input_index, std::uint32_t row_index) {
 
                         if (public_input_column_size(public_input_index) <= row_index)
-                            this->_public_table._public_inputs[public_input_index].resize(row_index + 1);
+                            this->_public_table->_public_inputs[public_input_index].resize(row_index + 1);
 
-                        return this->_public_table._public_inputs[public_input_index][row_index];
+                        return this->_public_table->_public_inputs[public_input_index][row_index];
                     }
 
-
                     const ColumnType& constant(std::uint32_t index) const {
-                        return _public_table.constant(index);
+                        return _public_table->constant(index);
                     }
 
                     typename field_type::value_type &constant(
                         std::uint32_t constant_index, std::uint32_t row_index) {
 
                         if (constant_column_size(constant_index) <= row_index)
-                            this->_public_table._constants[constant_index].resize(row_index + 1);
+                            this->_public_table->_constants[constant_index].resize(row_index + 1);
 
-                        return this->_public_table._constants[constant_index][row_index];
+                        return this->_public_table->_constants[constant_index][row_index];
                     }
 
                     const ColumnType& selector(std::uint32_t index) const {
-                        return _public_table.selector(index);
+                        return _public_table->selector(index);
                     }
 
                     typename field_type::value_type &selector(
                         std::uint32_t selector_index, std::uint32_t row_index) {
 
                         if (selector_column_size(selector_index) <= row_index)
-                            this->_public_table._selectors[selector_index].resize(row_index + 1);
+                            this->_public_table->_selectors[selector_index].resize(row_index + 1);
 
-                        return this->_public_table._selectors[selector_index][row_index];
+                        return this->_public_table->_selectors[selector_index][row_index];
                     }
 
                     void enable_selector(const std::size_t selector_index, const std::size_t row_index) {
@@ -428,104 +433,104 @@ namespace nil {
                     }
 
                     virtual void fill_constant(std::uint32_t index, const ColumnType& column) {
-                        _public_table.fill_constant(index, column);
+                        _public_table->fill_constant(index, column);
                     }
 
                     virtual void fill_selector(std::uint32_t index, const ColumnType& column) {
-                        _public_table.fill_selector(index, column);
+                        _public_table->fill_selector(index, column);
                     }
 
                     const witnesses_container_type& witnesses() const {
-                        return _private_table.witnesses();
+                        return _private_table->witnesses();
                     }
 
                     const public_input_container_type& public_inputs() const {
-                        return _public_table.public_inputs();
+                        return _public_table->public_inputs();
                     }
 
                     const constant_container_type& constants() const {
-                        return _public_table.constants();
+                        return _public_table->constants();
                     }
 
                     const selector_container_type& selectors() const {
-                        return _public_table.selectors();
+                        return _public_table->selectors();
                     }
 
                     virtual void resize_witnesses(std::uint32_t new_size) {
-                        _private_table.resize_witnesses(new_size);
+                        _private_table->resize_witnesses(new_size);
                     }
 
                     virtual void resize_public_inputs(std::uint32_t new_size) {
-                        _public_table.resize_public_inputs(new_size);
+                        _public_table->resize_public_inputs(new_size);
                     }
 
                     virtual void resize_constants(std::uint32_t new_size) {
-                        _public_table.resize_constants(new_size);
+                        _public_table->resize_constants(new_size);
                     }
 
                     virtual void resize_selectors(std::uint32_t new_size) {
-                        _public_table.resize_selectors(new_size);
+                        _public_table->resize_selectors(new_size);
                     }
 
                     const ColumnType& operator[](std::uint32_t index) const {
-                        if (index < _private_table.size())
-                            return _private_table[index];
-                        index -= _private_table.size();
-                        if (index < _public_table.size())
-                            return _public_table[index];
+                        if (index < _private_table->size())
+                            return (*_private_table)[index];
+                        index -= _private_table->size();
+                        if (index < _public_table->size())
+                            return (*_public_table)[index];
                         throw std::out_of_range("Private table index out of range.");
                     }
 
-                    const private_table_type& private_table() const {
+                    std::shared_ptr<private_table_type> private_table() const {
                         return _private_table;
                     }
 
-                    private_table_type move_private_table() {
+                    std::shared_ptr<private_table_type> move_private_table() {
                         return std::move(_private_table);
                     }
 
-                    const public_table_type& public_table() const {
+                    std::shared_ptr<public_table_type> public_table() const {
                         return _public_table;
                     }
 
-                    public_table_type move_public_table() {
+                    std::shared_ptr<public_table_type> move_public_table() {
                         return std::move(_public_table);
                     }
 
                     std::uint32_t size() const {
-                        return _private_table.size() + _public_table.size();
+                        return _private_table->size() + _public_table->size();
                     }
 
                     std::uint32_t witnesses_amount() const {
-                        return _private_table.witnesses_amount();
+                        return _private_table->witnesses_amount();
                     }
 
                     std::uint32_t witness_column_size(std::uint32_t index) const {
-                        return _private_table.witness_column_size(index);
+                        return _private_table->witness_column_size(index);
                     }
 
                     std::uint32_t public_inputs_amount() const {
-                        return _public_table.public_inputs_amount();
+                        return _public_table->public_inputs_amount();
                     }
 
                     std::uint32_t public_input_column_size(std::uint32_t index) const {
-                        return _public_table.public_input_column_size(index);
+                        return _public_table->public_input_column_size(index);
                     }
 
                     std::uint32_t constants_amount() const {
-                        return _public_table.constants_amount();
+                        return _public_table->constants_amount();
                     }
 
                     std::uint32_t constant_column_size(std::uint32_t index) const {
-                        return _public_table.constant_column_size(index);
+                        return _public_table->constant_column_size(index);
                     }
 
                     std::uint32_t selectors_amount() const {
-                        return _public_table.selectors_amount();
+                        return _public_table->selectors_amount();
                     }
 
                     std::uint32_t selector_column_size(std::uint32_t index) const {
-                        return _public_table.selector_column_size(index);
+                        return _public_table->selector_column_size(index);
                     }
 
                     std::uint32_t rows_amount() const {
@@ -555,7 +560,7 @@ namespace nil {
                     }
 
                     bool operator==(plonk_table<FieldType, ColumnType> const &other) const {
-                        return _private_table == other._private_table && _public_table == other._public_table;
+                        return *_private_table == *other._private_table && *_public_table == *other._public_table;
                     }
 
                     friend std::uint32_t basic_padding<FieldType, ColumnType>(

--- a/parallel-crypto3/libs/parallel-zk/include/nil/crypto3/zk/snark/arithmetization/plonk/padding.hpp
+++ b/parallel-crypto3/libs/parallel-zk/include/nil/crypto3/zk/snark/arithmetization/plonk/padding.hpp
@@ -97,27 +97,27 @@ namespace nil {
                     //std::cout << "usable_rows_amount = " << usable_rows_amount << std::endl;
                     //std::cout << "padded_rows_amount = " << padded_rows_amount << std::endl;
 
-                    for (std::uint32_t w_index = 0; w_index < table._private_table.witnesses_amount(); w_index++) {
-                        table._private_table._witnesses[w_index].resize(usable_rows_amount, FieldType::value_type::zero());
+                    for (std::uint32_t w_index = 0; w_index < table._private_table->witnesses_amount(); w_index++) {
+                        table._private_table->_witnesses[w_index].resize(usable_rows_amount, FieldType::value_type::zero());
                     }
 
-                    for (std::uint32_t pi_index = 0; pi_index < table._public_table.public_inputs_amount(); pi_index++) {
-                        table._public_table._public_inputs[pi_index].resize(padded_rows_amount, FieldType::value_type::zero());
+                    for (std::uint32_t pi_index = 0; pi_index < table._public_table->public_inputs_amount(); pi_index++) {
+                        table._public_table->_public_inputs[pi_index].resize(padded_rows_amount, FieldType::value_type::zero());
                     }
 
-                    for (std::uint32_t c_index = 0; c_index < table._public_table.constants_amount(); c_index++) {
-                        table._public_table._constants[c_index].resize(padded_rows_amount, FieldType::value_type::zero());
+                    for (std::uint32_t c_index = 0; c_index < table._public_table->constants_amount(); c_index++) {
+                        table._public_table->_constants[c_index].resize(padded_rows_amount, FieldType::value_type::zero());
                     }
 
-                    for (std::uint32_t s_index = 0; s_index < table._public_table.selectors_amount(); s_index++) {
-                        table._public_table._selectors[s_index].resize(padded_rows_amount, FieldType::value_type::zero());
+                    for (std::uint32_t s_index = 0; s_index < table._public_table->selectors_amount(); s_index++) {
+                        table._public_table->_selectors[s_index].resize(padded_rows_amount, FieldType::value_type::zero());
                     }
 
 
-                    for (std::uint32_t w_index = 0; w_index < table._private_table.witnesses_amount(); w_index++) {
-                        table._private_table._witnesses[w_index].resize(padded_rows_amount);
+                    for (std::uint32_t w_index = 0; w_index < table._private_table->witnesses_amount(); w_index++) {
+                        table._private_table->_witnesses[w_index].resize(padded_rows_amount);
                         for(std::size_t i = usable_rows_amount; i < padded_rows_amount; i++) {
-                            table._private_table._witnesses[w_index][i] = alg_rnd();
+                            table._private_table->_witnesses[w_index][i] = alg_rnd();
                         }
                     }
 

--- a/parallel-crypto3/libs/parallel-zk/include/nil/crypto3/zk/snark/systems/plonk/placeholder/gates_argument.hpp
+++ b/parallel-crypto3/libs/parallel-zk/include/nil/crypto3/zk/snark/systems/plonk/placeholder/gates_argument.hpp
@@ -80,7 +80,7 @@ namespace nil {
 
                     static inline void build_variable_value_map(
                         const math::expression<variable_type>& expr,
-                        const plonk_polynomial_dfs_table<FieldType> &assignments,
+                        const plonk_polynomial_dfs_table<FieldType>& assignments,
                         std::shared_ptr<math::evaluation_domain<FieldType>> domain,
                         std::size_t extended_domain_size,
                         std::unordered_map<variable_type, polynomial_dfs_type>& variable_values_out,
@@ -135,8 +135,7 @@ namespace nil {
 
                     static inline std::array<polynomial_dfs_type, argument_size> prove_eval(
                         const typename policy_type::constraint_system_type &constraint_system,
-                        const plonk_polynomial_dfs_table<FieldType>
-                            &column_polynomials,
+                        const plonk_polynomial_dfs_table<FieldType> &column_polynomials,
                         std::shared_ptr<math::evaluation_domain<FieldType>> original_domain,
                         std::uint32_t max_gates_degree,
                         const polynomial_dfs_type &mask_polynomial,

--- a/parallel-crypto3/libs/parallel-zk/include/nil/crypto3/zk/snark/systems/plonk/placeholder/lookup_argument.hpp
+++ b/parallel-crypto3/libs/parallel-zk/include/nil/crypto3/zk/snark/systems/plonk/placeholder/lookup_argument.hpp
@@ -138,8 +138,7 @@ namespace nil {
                                 &constraint_system,
                             const typename placeholder_public_preprocessor<FieldType, ParamsType>::preprocessed_data_type
                                 &preprocessed_data,
-                            const plonk_polynomial_dfs_table<FieldType>
-                                &plonk_columns,
+                            const plonk_polynomial_dfs_table<FieldType>& plonk_columns,
                             commitment_scheme_type &commitment_scheme,
                             transcript_type &transcript)
                         : constraint_system(constraint_system)
@@ -704,7 +703,7 @@ namespace nil {
 
                     const plonk_constraint_system<FieldType> &constraint_system;
                     const typename placeholder_public_preprocessor<FieldType, ParamsType>::preprocessed_data_type& preprocessed_data;
-                    const plonk_polynomial_dfs_table<FieldType> &plonk_columns;
+                    const plonk_polynomial_dfs_table<FieldType>& plonk_columns;
                     commitment_scheme_type& commitment_scheme;
                     transcript_type& transcript;
                     std::shared_ptr<math::evaluation_domain<FieldType>> basic_domain;

--- a/parallel-crypto3/libs/parallel-zk/include/nil/crypto3/zk/snark/systems/plonk/placeholder/permutation_argument.hpp
+++ b/parallel-crypto3/libs/parallel-zk/include/nil/crypto3/zk/snark/systems/plonk/placeholder/permutation_argument.hpp
@@ -43,6 +43,7 @@
 #include <nil/crypto3/zk/snark/systems/plonk/placeholder/params.hpp>
 #include <nil/crypto3/zk/snark/systems/plonk/placeholder/detail/placeholder_policy.hpp>
 #include <nil/crypto3/zk/snark/systems/plonk/placeholder/preprocessor.hpp>
+#include <nil/crypto3/zk/snark/arithmetization/plonk/assignment.hpp>
 
 #include <nil/crypto3/bench/scoped_profiler.hpp>
 
@@ -76,7 +77,7 @@ namespace nil {
                         const typename placeholder_public_preprocessor<FieldType, ParamsType>::preprocessed_data_type
                             preprocessed_data,
                         const plonk_table_description<FieldType> &table_description,
-                        const plonk_polynomial_dfs_table<FieldType> &column_polynomials,
+                        const plonk_polynomial_dfs_table<FieldType>& column_polynomials,
                         typename ParamsType::commitment_scheme_type& commitment_scheme,
                         transcript_type& transcript
                     ) {

--- a/parallel-crypto3/libs/parallel-zk/include/nil/crypto3/zk/snark/systems/plonk/placeholder/preprocessor.hpp
+++ b/parallel-crypto3/libs/parallel-zk/include/nil/crypto3/zk/snark/systems/plonk/placeholder/preprocessor.hpp
@@ -76,6 +76,7 @@ namespace nil {
                     using commitment_type = typename commitment_scheme_type::commitment_type;
                     using transcript_type = typename commitment_scheme_type::transcript_type;
                     using transcript_hash_type = typename commitment_scheme_type::transcript_hash_type;
+                    using public_assignment_type = typename policy_type::variable_assignment_type::public_table_type;
 
                 public:
                     static std::size_t permutation_partitions_num(
@@ -264,7 +265,7 @@ namespace nil {
                         };
 
                         bool operator==(const preprocessed_data_type &rhs) const {
-                            return public_polynomial_table == rhs.public_polynomial_table &&
+                            return shared_ptr_equal(public_polynomial_table, rhs.public_polynomial_table) && 
                                 permutation_polynomials == rhs.permutation_polynomials &&
                                 identity_polynomials == rhs.identity_polynomials &&
                                 q_last == rhs.q_last &&
@@ -276,7 +277,7 @@ namespace nil {
                             return !(rhs == *this);
                         }
 
-                        plonk_public_polynomial_dfs_table_type public_polynomial_table;
+                        std::shared_ptr<plonk_public_polynomial_dfs_table_type> public_polynomial_table;
 
                         // S_sigma
                         std::vector<polynomial_dfs_type>  permutation_polynomials;
@@ -287,6 +288,19 @@ namespace nil {
                         polynomial_dfs_type q_blind;
 
                         common_data_type common_data;
+
+                    private:
+                        template<typename T>
+                        static bool shared_ptr_equal(const std::shared_ptr<T> &lhs, const std::shared_ptr<T> &rhs) {
+                            bool both_null = (lhs == nullptr && rhs == nullptr);
+                            if (both_null) {
+                                return true;
+                            }
+                            if (lhs == nullptr || rhs == nullptr) {
+                                return false;
+                            }
+                            return *lhs == *rhs;
+                        }
                     };
 
                 private:
@@ -383,6 +397,18 @@ namespace nil {
                             return _mapping[key];
                         }
                     };
+
+                    static inline std::shared_ptr<plonk_public_polynomial_dfs_table<FieldType>> convert_public_table(
+                        std::shared_ptr<public_assignment_type> public_assignment,
+                        std::shared_ptr<math::evaluation_domain<FieldType>> basic_domain
+                    ) {
+                        return std::make_shared<plonk_public_polynomial_dfs_table<FieldType>>(    
+                            detail::column_range_polynomial_dfs<FieldType>(public_assignment->public_inputs(), basic_domain),
+                            detail::column_range_polynomial_dfs<FieldType>(public_assignment->constants(), basic_domain),
+                            detail::column_range_polynomial_dfs<FieldType>(public_assignment->selectors(), basic_domain)
+                        );
+                    }
+
 
                 public:
                     static inline std::vector<std::set<int>>
@@ -535,7 +561,7 @@ namespace nil {
                     // TODO: columns_with_copy_constraints -- It should be extracted from constraint_system
                     static inline preprocessed_data_type process(
                         const plonk_constraint_system<FieldType> &constraint_system,
-                        typename policy_type::variable_assignment_type::public_table_type public_assignment,
+                        std::shared_ptr<public_assignment_type> public_assignment,
                         const plonk_table_description<FieldType>
                             &table_description,
                         typename ParamsType::commitment_scheme_type &commitment_scheme,
@@ -580,15 +606,7 @@ namespace nil {
                         q_last_q_blind[0] = lagrange_polynomial(basic_domain, usable_rows);
                         q_last_q_blind[1] = selector_blind(usable_rows, basic_domain);
 
-                        plonk_public_polynomial_dfs_table<FieldType>
-                            public_polynomial_table =
-                                plonk_public_polynomial_dfs_table<FieldType>(
-                                    detail::column_range_polynomial_dfs<FieldType>(public_assignment.move_public_inputs(),
-                                                                                   basic_domain),
-                                    detail::column_range_polynomial_dfs<FieldType>(public_assignment.move_constants(),
-                                                                                   basic_domain),
-                                    detail::column_range_polynomial_dfs<FieldType>(public_assignment.move_selectors(),
-                                                                                   basic_domain));
+                        auto public_polynomial_table = convert_public_table(std::move(public_assignment), basic_domain);
 
                         // prepare commitments for short verifier
                         //typename preprocessed_data_type::public_precommitments_type public_precommitments =
@@ -600,7 +618,7 @@ namespace nil {
                         std::size_t lookup_parts_num = constraint_system.lookup_parts(max_quotient_poly_chunks).size();
 
                         typename preprocessed_data_type::public_commitments_type public_commitments = commitments(
-                            public_polynomial_table, id_perm_polys,
+                            *public_polynomial_table, id_perm_polys,
                             sigma_perm_polys, q_last_q_blind, commitment_scheme
                         );
 
@@ -658,12 +676,14 @@ namespace nil {
                     struct preprocessed_data_type {
                         std::shared_ptr<math::evaluation_domain<FieldType>> basic_domain;
 
-                        plonk_private_polynomial_dfs_table<FieldType> private_polynomial_table;
+                        std::shared_ptr<plonk_private_polynomial_dfs_table<FieldType>> private_polynomial_table;
                     };
+
+                    using private_assignment_type = typename policy_type::variable_assignment_type::private_table_type;
 
                     static inline preprocessed_data_type process(
                         const plonk_constraint_system<FieldType>  &constraint_system,
-                        typename policy_type::variable_assignment_type::private_table_type private_assignment,
+                        std::shared_ptr<private_assignment_type> private_assignment,
                         const plonk_table_description<FieldType>  &table_description
                     ) {
                         std::size_t N_rows = table_description.rows_amount;
@@ -671,10 +691,13 @@ namespace nil {
                         std::shared_ptr<math::evaluation_domain<FieldType>> basic_domain =
                             math::make_evaluation_domain<FieldType>(N_rows);
 
-                        plonk_private_polynomial_dfs_table<FieldType>
-                            private_polynomial_table(detail::column_range_polynomial_dfs<FieldType>(
-                                private_assignment.move_witnesses(), basic_domain));
-                        return preprocessed_data_type({basic_domain, std::move(private_polynomial_table)});
+                        auto private_polynomial_table = std::make_shared<plonk_private_polynomial_dfs_table<FieldType>>(
+                            detail::column_range_polynomial_dfs<FieldType>(
+                                private_assignment->witnesses(),
+                                basic_domain
+                            )
+                        );
+                        return preprocessed_data_type({basic_domain, private_polynomial_table});
                     }
                 };
             }    // namespace snark

--- a/parallel-crypto3/libs/parallel-zk/include/nil/crypto3/zk/snark/systems/plonk/placeholder/verifier.hpp
+++ b/parallel-crypto3/libs/parallel-zk/include/nil/crypto3/zk/snark/systems/plonk/placeholder/verifier.hpp
@@ -150,7 +150,7 @@ namespace nil {
                         const placeholder_proof<FieldType, ParamsType> &proof,
                         const plonk_table_description<FieldType> &table_description,
                         const plonk_constraint_system<FieldType> &constraint_system,
-                        commitment_scheme_type commitment_scheme,
+                        commitment_scheme_type& commitment_scheme,
                         const std::vector<std::vector<typename FieldType::value_type>> &public_input
                     ){
                         // TODO: process rotations for public input.
@@ -191,7 +191,7 @@ namespace nil {
                         const placeholder_proof<FieldType, ParamsType> &proof,
                         const plonk_table_description<FieldType> &table_description,
                         const plonk_constraint_system<FieldType> &constraint_system,
-                        commitment_scheme_type commitment_scheme
+                        commitment_scheme_type& commitment_scheme
                     ) {
 
                         // We cannot add eval points unless everything is committed, so when verifying assume it's committed.

--- a/parallel-crypto3/libs/parallel-zk/test/systems/plonk/placeholder/circuits.hpp
+++ b/parallel-crypto3/libs/parallel-zk/test/systems/plonk/placeholder/circuits.hpp
@@ -177,8 +177,8 @@ namespace nil {
                         public_input_assignment[i] = table[witness_columns + i];
                     }
                     test_circuit.table = plonk_assignment_table<FieldType>(
-                        plonk_private_assignment_table<FieldType>(private_assignment),
-                        plonk_public_assignment_table<FieldType>(
+                        std::make_shared<plonk_private_assignment_table<FieldType>>(private_assignment),
+                        std::make_shared<plonk_public_assignment_table<FieldType>>(
                             public_input_assignment, constant_assignment, selectors_assignment));
 
                     test_circuit.table_rows = zk_padding<FieldType, plonk_column<FieldType>>(test_circuit.table, alg_rnd);
@@ -316,8 +316,8 @@ namespace nil {
                         public_input_assignment[i] = table[witness_columns + i];
                     }
                     test_circuit.table = plonk_assignment_table<FieldType>(
-                        plonk_private_assignment_table<FieldType>(private_assignment),
-                        plonk_public_assignment_table<FieldType>(
+                        std::make_shared<plonk_private_assignment_table<FieldType>>(private_assignment),
+                        std::make_shared<plonk_public_assignment_table<FieldType>>(
                             public_input_assignment, constant_assignment, selectors_assignment));
                     test_circuit.table_rows = zk_padding<FieldType, plonk_column<FieldType>>(test_circuit.table, alg_rnd);
 
@@ -414,8 +414,8 @@ namespace nil {
                         constant_assignment[i] = table[witness_columns + i];
                     }
                     test_circuit.table = plonk_assignment_table<FieldType>(
-                        plonk_private_assignment_table<FieldType>(private_assignment),
-                        plonk_public_assignment_table<FieldType>(
+                        std::make_shared<plonk_private_assignment_table<FieldType>>(private_assignment),
+                        std::make_shared<plonk_public_assignment_table<FieldType>>(
                             public_input_assignment, constant_assignment, selectors_assignment));
                     test_circuit.table_rows = zk_padding(test_circuit.table, alg_rnd);
 
@@ -521,8 +521,8 @@ namespace nil {
                         constant_assignment[i] = table[witness_columns + i];
                     }
                     test_circuit.table = plonk_assignment_table<FieldType>(
-                        plonk_private_assignment_table<FieldType>(private_assignment),
-                        plonk_public_assignment_table<FieldType>(
+                        std::make_shared<plonk_private_assignment_table<FieldType>>(private_assignment),
+                        std::make_shared<plonk_public_assignment_table<FieldType>>(
                             public_input_assignment, constant_assignment, selectors_assignment));
 
 
@@ -618,8 +618,8 @@ namespace nil {
                     selectors_assignment[0][1] = 1u;
 
                     test_circuit.table = plonk_assignment_table<FieldType>(
-                        plonk_private_assignment_table<FieldType>(private_assignment),
-                        plonk_public_assignment_table<FieldType>(
+                        std::make_shared<plonk_private_assignment_table<FieldType>>(private_assignment),
+                        std::make_shared<plonk_public_assignment_table<FieldType>>(
                             public_input_assignment, constant_assignment, selectors_assignment));
                     test_circuit.table_rows = zk_padding<FieldType, plonk_column<FieldType>>(test_circuit.table, alg_rnd);
 
@@ -714,8 +714,8 @@ namespace nil {
 
 
                     test_circuit.table = plonk_assignment_table<FieldType>(
-                        plonk_private_assignment_table<FieldType>(private_assignment),
-                        plonk_public_assignment_table<FieldType>(
+                        std::make_shared<plonk_private_assignment_table<FieldType>>(private_assignment),
+                        std::make_shared<plonk_public_assignment_table<FieldType>>(
                             public_input_assignment, constant_assignment, selectors_assignment));
                     test_circuit.table_rows = zk_padding<FieldType, plonk_column<FieldType>>(test_circuit.table, alg_rnd);
 
@@ -820,8 +820,8 @@ namespace nil {
                         constant_assignment[i] = table[witness_columns + selector_columns + i];
                     }
                     test_circuit.table = plonk_assignment_table<FieldType>(
-                        plonk_private_assignment_table<FieldType>(private_assignment),
-                        plonk_public_assignment_table<FieldType>(
+                        std::make_shared<plonk_private_assignment_table<FieldType>>(private_assignment),
+                        std::make_shared<plonk_public_assignment_table<FieldType>>(
                             public_input_assignment, constant_assignment, selectors_assignment));
                     test_circuit.table_rows = zk_padding(test_circuit.table, alg_rnd);
 
@@ -972,8 +972,8 @@ namespace nil {
                     std::vector<plonk_column<FieldType>> public_input_assignment(public_columns);
 
                     test_circuit.table = plonk_assignment_table<FieldType>(
-                        plonk_private_assignment_table<FieldType>(private_assignment),
-                        plonk_public_assignment_table<FieldType>(
+                        std::make_shared<plonk_private_assignment_table<FieldType>>(private_assignment),
+                        std::make_shared<plonk_public_assignment_table<FieldType>>(
                             public_input_assignment, constant_assignment, selectors_assignment));
                     test_circuit.table_rows = zk_padding(test_circuit.table, alg_rnd);
 
@@ -1129,8 +1129,8 @@ namespace nil {
                     }
 
                     test_circuit.table = plonk_assignment_table<FieldType>(
-                        plonk_private_assignment_table<FieldType>(private_assignment),
-                        plonk_public_assignment_table<FieldType>(
+                        std::make_shared<plonk_private_assignment_table<FieldType>>(private_assignment),
+                        std::make_shared<plonk_public_assignment_table<FieldType>>(
                             public_input_assignment,
                             constant_assignment,
                             selector_assignment

--- a/parallel-crypto3/libs/parallel-zk/test/systems/plonk/placeholder/placeholder_permutation_argument.cpp
+++ b/parallel-crypto3/libs/parallel-zk/test/systems/plonk/placeholder/placeholder_permutation_argument.cpp
@@ -130,12 +130,12 @@ BOOST_AUTO_TEST_SUITE(permutation_argument)
 
         typename placeholder_public_preprocessor<field_type, lpc_placeholder_params_type>::preprocessed_data_type
                 lpc_preprocessed_public_data = placeholder_public_preprocessor<field_type, lpc_placeholder_params_type>::process(
-                constraint_system, assignments.move_public_table(), desc, lpc_scheme
+                constraint_system, assignments.public_table(), desc, lpc_scheme
         );
 
         typename placeholder_private_preprocessor<field_type, lpc_placeholder_params_type>::preprocessed_data_type
                 lpc_preprocessed_private_data = placeholder_private_preprocessor<field_type, lpc_placeholder_params_type>::process(
-                constraint_system, assignments.move_private_table(), desc
+                constraint_system, assignments.private_table(), desc
         );
 
         auto polynomial_table =
@@ -237,12 +237,12 @@ BOOST_AUTO_TEST_SUITE(permutation_argument)
 
         typename placeholder_public_preprocessor<field_type, lpc_placeholder_params_type>::preprocessed_data_type
                 preprocessed_public_data = placeholder_public_preprocessor<field_type, lpc_placeholder_params_type>::process(
-                constraint_system, assignments.move_public_table(), desc, lpc_scheme
+                constraint_system, assignments.public_table(), desc, lpc_scheme
         );
 
         typename placeholder_private_preprocessor<field_type, lpc_placeholder_params_type>::preprocessed_data_type
                 preprocessed_private_data = placeholder_private_preprocessor<field_type, lpc_placeholder_params_type>::process(
-                constraint_system, assignments.move_private_table(), desc
+                constraint_system, assignments.private_table(), desc
         );
 
         auto polynomial_table =

--- a/parallel-crypto3/libs/parallel-zk/test/systems/plonk/placeholder/placeholder_test_runner.hpp
+++ b/parallel-crypto3/libs/parallel-zk/test/systems/plonk/placeholder/placeholder_test_runner.hpp
@@ -94,11 +94,11 @@ struct placeholder_test_runner {
 
         typename placeholder_public_preprocessor<field_type, lpc_placeholder_params_type>::preprocessed_data_type
                 lpc_preprocessed_public_data = placeholder_public_preprocessor<field_type, lpc_placeholder_params_type>::process(
-                constraint_system, assignments.move_public_table(), desc, lpc_scheme, max_quotient_poly_chunks);
+                constraint_system, assignments.public_table(), desc, lpc_scheme, max_quotient_poly_chunks);
 
         typename placeholder_private_preprocessor<field_type, lpc_placeholder_params_type>::preprocessed_data_type
                 lpc_preprocessed_private_data = placeholder_private_preprocessor<field_type, lpc_placeholder_params_type>::process(
-                constraint_system, assignments.move_private_table(), desc);
+                constraint_system, assignments.private_table(), desc);
 
         auto lpc_proof = placeholder_prover<field_type, lpc_placeholder_params_type>::process(
                 lpc_preprocessed_public_data, std::move(lpc_preprocessed_private_data), desc, constraint_system,

--- a/parallel-crypto3/libs/parallel-zk/test/systems/plonk/plonk_constraint.cpp
+++ b/parallel-crypto3/libs/parallel-zk/test/systems/plonk/plonk_constraint.cpp
@@ -79,9 +79,11 @@ BOOST_AUTO_TEST_CASE(plonk_constraint_basic_test) {
     std::cout << witness_columns[1][0].data << std::endl;
     std::cout << witness_columns[2][0].data << std::endl;
 
-    zk::snark::plonk_private_assignment_table<FieldType> private_assignment(witness_columns);
+    auto private_assignment = std::make_shared<zk::snark::plonk_private_assignment_table<FieldType>>(witness_columns);
 
-    zk::snark::plonk_assignment_table<FieldType> assignment(private_assignment);
+    zk::snark::plonk_assignment_table<FieldType> assignment(private_assignment,
+        std::make_shared<zk::snark::plonk_public_assignment_table<FieldType>>()
+    );
 
     BOOST_CHECK((witness_columns[0][0] + witness_columns[1][0] - witness_columns[2][0]) ==
                 constraint.evaluate(0, assignment));

--- a/proof-producer/bin/proof-producer/include/nil/proof-generator/prover.hpp
+++ b/proof-producer/bin/proof-producer/include/nil/proof-generator/prover.hpp
@@ -246,23 +246,31 @@ namespace nil {
                 BOOST_ASSERT(lpc_scheme_);
 
                 BOOST_LOG_TRIVIAL(info) << "Generating proof...";
-                Proof proof = nil::crypto3::zk::snark::placeholder_prover<BlueprintField, PlaceholderParams>::process(
+                nil::crypto3::zk::snark::placeholder_prover<BlueprintField, PlaceholderParams> prover(
                     *public_preprocessed_data_,
                     *private_preprocessed_data_,
                     *table_description_,
                     *constraint_system_,
-                    *lpc_scheme_
+                    std::move(*lpc_scheme_)
                 );
+                auto proof = prover.process();
                 BOOST_LOG_TRIVIAL(info) << "Proof generated";
 
+                create_lpc_scheme(); // reset to default scheme to do the verification
+                bool verify_ok{};
                 if (skip_verification) {
                     BOOST_LOG_TRIVIAL(info) << "Skipping proof verification";
+                    verify_ok = true;
                 } else {
-                    if (!verify(proof)) {
-                        return false;
-                    }
+                    verify_ok = verify(proof);
                 }
+                lpc_scheme_.emplace(std::move(prover.move_commitment_scheme())); // get back the commitment scheme used in prover
 
+                if (!verify_ok) {
+                    BOOST_LOG_TRIVIAL(error) << "Proof verification failed";
+                    return false;
+                }
+                
                 BOOST_LOG_TRIVIAL(info) << "Writing proof to " << proof_file_;
                 auto filled_placeholder_proof =
                     nil::crypto3::marshalling::types::fill_placeholder_proof<Endianness, Proof>(proof, lpc_scheme_->get_fri_params());
@@ -316,7 +324,7 @@ namespace nil {
                         *private_preprocessed_data_,
                         *table_description_,
                         *constraint_system_,
-                        *lpc_scheme_,
+                        std::move(*lpc_scheme_),
                         true);
                 Proof proof = prover.process();
                 BOOST_LOG_TRIVIAL(info) << "Proof generated";
@@ -358,19 +366,19 @@ namespace nil {
                     BOOST_LOG_TRIVIAL(error) << "Failed to write challenge to file.";
                 }
 
-                auto commitment_scheme = prover.get_commitment_scheme();
+                lpc_scheme_.emplace(prover.move_commitment_scheme());
 
-                commitment_scheme.state_commited(crypto3::zk::snark::FIXED_VALUES_BATCH);
-                commitment_scheme.state_commited(crypto3::zk::snark::VARIABLE_VALUES_BATCH);
-                commitment_scheme.state_commited(crypto3::zk::snark::PERMUTATION_BATCH);
-                commitment_scheme.state_commited(crypto3::zk::snark::QUOTIENT_BATCH);
-                commitment_scheme.state_commited(crypto3::zk::snark::LOOKUP_BATCH);
-                commitment_scheme.mark_batch_as_fixed(crypto3::zk::snark::FIXED_VALUES_BATCH);
+                lpc_scheme_->state_commited(crypto3::zk::snark::FIXED_VALUES_BATCH);
+                lpc_scheme_->state_commited(crypto3::zk::snark::VARIABLE_VALUES_BATCH);
+                lpc_scheme_->state_commited(crypto3::zk::snark::PERMUTATION_BATCH);
+                lpc_scheme_->state_commited(crypto3::zk::snark::QUOTIENT_BATCH);
+                lpc_scheme_->state_commited(crypto3::zk::snark::LOOKUP_BATCH);
+                lpc_scheme_->mark_batch_as_fixed(crypto3::zk::snark::FIXED_VALUES_BATCH);
 
-                commitment_scheme.set_fixed_polys_values(common_data_.has_value() ? common_data_->commitment_scheme_data :
+                lpc_scheme_->set_fixed_polys_values(common_data_.has_value() ? common_data_->commitment_scheme_data :
                                                                                     public_preprocessed_data_->common_data.commitment_scheme_data);
 
-                std::size_t theta_power = commitment_scheme.compute_theta_power_for_combined_Q();
+                std::size_t theta_power = lpc_scheme_->compute_theta_power_for_combined_Q();
 
                 auto output_file = open_file<std::ofstream>(theta_power_file->string(), std::ios_base::out);
                 (*output_file) << theta_power << std::endl;
@@ -512,14 +520,13 @@ namespace nil {
                     return false;
                 }
 
-                lpc_scheme_.emplace(commitment_scheme.value());
+                lpc_scheme_.emplace(std::move(commitment_scheme.value()));
                 return true;
             }
 
-            bool verify(const Proof& proof) const {
+            bool verify(const Proof& proof) {
                 BOOST_LOG_TRIVIAL(info) << "Verifying proof...";
-                bool verification_result =
-                    nil::crypto3::zk::snark::placeholder_verifier<BlueprintField, PlaceholderParams>::process(
+                bool verification_result = nil::crypto3::zk::snark::placeholder_verifier<BlueprintField, PlaceholderParams>::process(
                         public_preprocessed_data_.has_value() ? public_preprocessed_data_->common_data : *common_data_,
                         proof,
                         *table_description_,

--- a/proof-producer/bin/proof-producer/src/main.cpp
+++ b/proof-producer/bin/proof-producer/src/main.cpp
@@ -87,6 +87,7 @@ int run_prover(const nil::proof_generator::ProverOptions& prover_options) {
                         prover.save_preprocessed_common_data_to_file(prover_options.preprocessed_common_data_path) &&
                         prover.save_public_preprocessed_data_to_file(prover_options.preprocessed_public_data_path) &&
                         prover.save_commitment_state_to_file(prover_options.commitment_scheme_state_path)&&
+                        prover.save_assignment_description(prover_options.assignment_description_file_path) &&
                         prover.print_evm_verifier(prover_options.evm_verifier_path);
                     break;
                 case nil::proof_generator::detail::ProverStage::PROVE:


### PR DESCRIPTION
found redundant copies of large objects (public assignment table parts & commitment schemes)
- moved commitment scheme to prover and back
- added non-owning plonk_table_view class for reducing copies of table parts

Commit also includes logic change: now proof-producer saves to file commitment scheme modified by the prover instead of one fetched from the preprocessor. The same modified table is also passed to the verifier as it does not affects the verification.

SHA256 memory peak: 65 --> 59GB