### PR TITLE
fix redundant parallel-crypto3 test build

### DIFF
--- a/parallel-crypto3/libs/parallel-containers/CMakeLists.txt
+++ b/parallel-crypto3/libs/parallel-containers/CMakeLists.txt
@@ -75,9 +75,7 @@ target_include_directories(${CMAKE_WORKSPACE_NAME}_${CURRENT_PROJECT_NAME} INTER
 
         ${Boost_INCLUDE_DIRS})
 
-if (BUILD_TESTS)
-    add_subdirectory(test)
-endif ()
+add_tests(test)
 
 if (BUILD_EXAMPLES)
     add_subdirectory(example)


### PR DESCRIPTION
Due to invalid test subdirectory adding parallel crypto3 test build leaked into each dependent binary compilation
