### PR TITLE
Fix typos and grammatical issues in documentation files

### DIFF
--- a/crypto3/libs/algebra/docs/implementation.md
+++ b/crypto3/libs/algebra/docs/implementation.md
@@ -162,7 +162,7 @@ It also contains `pairing_policy` type, needed for comfortable usage of curve pa
 
 ### Curve Element Algorithms ### {#curve_element_algorithms}
 
-Curve element corresponds an point of the curve and has all the needed methods and overloaded arithmetic operators. The corresponding algorithms 
+Curve element corresponds a point of the curve and has all the needed methods and overloaded arithmetic operators. The corresponding algorithms 
 are based on the underlying field algorithms are also defined here.
 
 ### Basic Curve Policies ### {#basic_curve_policies}

--- a/evm-assigner/docs/efficient_gas_calculation_algorithm.md
+++ b/evm-assigner/docs/efficient_gas_calculation_algorithm.md
@@ -59,7 +59,7 @@ In EVM there are simple rules to identify basic instruction block boundaries:
    - `REVERT`,
    - `SELFDESTRUCT`.
 
-A basic instruction block is a shortest sequence of instructions such that 
+A basic instruction block is the shortest sequence of instructions such that 
 a basic block starts before the first instruction and ends after the last.
 
 In some cases multiple of the above rules can apply to single basic instruction 


### PR DESCRIPTION
This PR addresses minor grammatical issues and typos in the following documentation files:

1. **`implementation.md`**
   - Corrected "an point" to "a point" for proper article usage.

2. **`efficient_gas_calculation_algorithm.md`**
   - Replaced "a shortest sequence" with "the shortest sequence" to correctly use the definite article with a superlative.

These changes enhance the clarity and accuracy of the documentation without affecting the codebase functionality.
