### PR TITLE
Config files improvements

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -9,4 +9,5 @@ InsertNewlineAtEOF: true
 NamespaceIndentation: All
 SpaceAfterTemplateKeyword: false
 TabWidth: 4
+IncludeBlocks: Preserve
 ...

--- a/.envrc
+++ b/.envrc
@@ -1,1 +1,1 @@
-use flake
+use flake ${PLACEHOLDER_DEVELOP_DERIVATION:-.}

--- a/.gitignore
+++ b/.gitignore
@@ -347,6 +347,7 @@ modules.xml
 ### CMake ###
 CMakeLists.txt.user
 CMakeCache.txt
+CMakeUserPresets.json
 CMakeFiles
 CMakeScripts
 Testing
@@ -640,3 +641,9 @@ callgrind.*
 
 .ycm_extra_config.py
 .color_coded
+
+# VSCode configuration
+.vscode
+
+# direnv outputs
+.direnv

--- a/flake.nix
+++ b/flake.nix
@@ -109,7 +109,19 @@
             parallel_crypto3_tets = true;
             crypto3_bechmarks = true;
             parallel_crypto3_bechmarks = true;
-            });
+          });
+
+          develop-clang = (pkgs.callPackage ./proof-producer.nix {
+            stdenv = pkgs.llvmPackages_19.stdenv;
+            enableDebug = true;
+            runTests = true;
+            sanitize = true;
+            crypto3_tests = true;
+            parallel_crypto3_tets = true;
+            crypto3_bechmarks = true;
+            parallel_crypto3_bechmarks = true;
+          });
+
           # The "all" package will build all packages. Convenient for CI,
           # so that "nix build" will check that all packages are correct.
           # The packages that have no changes will not be rebuilt, and instead


### PR DESCRIPTION
`.clang-format`: preserve include blocks groups (instead of grouping all the includes and sorting them)
`.envrc`: allow specifying used derivation in environment (mainly so that whoever uses clang could just set `PLACEHOLDER_DEVELOP_DERIVATION` to `.#develop-clang`)
`.gitignore`: add vscode, direnv and cmake related files
`CMakeLists.txt`: enable tests in root too (so it works without `nix develop`)
`flake.nix`: add `develop-clang` derivation
