### PR TITLE
Add deb bundler for proof-producer package

### DIFF
--- a/.github/workflows/deb-package-proof-producer-bundler.yaml
+++ b/.github/workflows/deb-package-proof-producer-bundler.yaml
@@ -1,0 +1,23 @@
+name: Check Linux bundlers
+
+on:
+  workflow_call:
+
+jobs:
+  build-deb-package:
+    name: "Build proof-producer deb package"
+    runs-on: [self-hosted, Linux, X64, aws_autoscaling]
+    steps:
+      # https://github.com/actions/checkout/issues/1552
+      - name: Clean up after previous checkout
+        run: chmod +w -R ${GITHUB_WORKSPACE}; rm -rf ${GITHUB_WORKSPACE}/*;
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Build proof-producer deb package
+        run: |
+          nix bundle --bundler . .#proof-producer
+          ls -l ./deb-package-proof-producer/proof-producer_*_amd64.deb

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -19,6 +19,13 @@ jobs:
       always() && !cancelled()
     secrets: inherit
 
+  build-linux-proof-producer-deb-package:
+    name: Build deb package
+    uses: ./.github/workflows/deb-package-proof-producer-bundler.yaml
+    if: |
+      always() && !cancelled()
+    secrets: inherit
+
   post-telemetry:
     name: Post test results in Open Telemetry format
     runs-on: [self-hosted, Linux, X64, aws_autoscaling]

--- a/crypto3/CMakeLists.txt
+++ b/crypto3/CMakeLists.txt
@@ -16,8 +16,6 @@ include(CMSetupVersion)
 cm_workspace(crypto3)
 cm_setup_version(VERSION 0.3.0 PREFIX ${CMAKE_WORKSPACE_NAME})
 
-option(BUILD_SHARED_LIBS "Build shared library" FALSE) # TODO: it makes no sense for header-only lib, remove
-option(Boost_USE_STATIC_LIBS "Use static libraries for Boost" OFF)
 option(BUILD_TESTS "Enable tests" TRUE) # used by CMTest module; If set to false, tests are removed from crypto3::all target. User still can build individual ones.
 option(BUILD_CRYPTO3_TESTS "Enable tests" FALSE)
 option(BUILD_CRYPTO3_BENCH_TESTS "Build performance benchmark tests" FALSE)

--- a/proof-producer/CMakeLists.txt
+++ b/proof-producer/CMakeLists.txt
@@ -20,6 +20,16 @@ include(CMConfig)
 include(CMDeploy)
 include(CMSetupVersion)
 
+option(PROOF_PRODUCER_STATIC_BINARIES "Link proof-producer binaries statically" OFF)
+
+if(PROOF_PRODUCER_STATIC_BINARIES)
+    set(BUILD_SHARED_LIBS OFF)
+    set(Boost_USE_STATIC_LIBS ON)
+else()
+    set(BUILD_SHARED_LIBS OFF)  # TODO: fix invalid-pch issue with precompiled headers to build shared libraries
+    set(Boost_USE_STATIC_LIBS OFF)
+endif()
+
 cm_project(proof-producer WORKSPACE_NAME ${CMAKE_WORKSPACE_NAME} LANGUAGES CXX)
 
 # The file compile_commands.json is generated in build directory, so LSP could
@@ -27,7 +37,7 @@ cm_project(proof-producer WORKSPACE_NAME ${CMAKE_WORKSPACE_NAME} LANGUAGES CXX)
 # If Nix is used, LSP could not guess the locations of implicit include
 # directories, so we need to include them explicitly.
 if(CMAKE_EXPORT_COMPILE_COMMANDS)
-  set(CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES 
+  set(CMAKE_CXX_STANDARD_INCLUDE_DIRECTORIES
       ${CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES})
 endif()
 

--- a/proof-producer/bin/proof-producer/CMakeLists.txt
+++ b/proof-producer/bin/proof-producer/CMakeLists.txt
@@ -80,6 +80,10 @@ function(setup_proof_generator_target)
         target_compile_options(${ARG_TARGET_NAME} PRIVATE "-fconstexpr-ops-limit=4294967295")
     endif ()
 
+    if(PROOF_PRODUCER_STATIC_BINARIES)
+        target_link_options(${ARG_TARGET_NAME} PRIVATE -static -static-libgcc -static-libstdc++)
+    endif()
+
 endfunction()
 
 set(SINGLE_THREADED_TARGET "${CURRENT_PROJECT_NAME}-single-threaded")

--- a/proof-producer/libs/assigner/CMakeLists.txt
+++ b/proof-producer/libs/assigner/CMakeLists.txt
@@ -1,6 +1,4 @@
-find_package(Protobuf REQUIRED)
-find_package(absl REQUIRED)
-
+find_package(Protobuf CONFIG REQUIRED)
 
 file(GLOB PROTO_FILES "proto/*.proto")
 
@@ -14,7 +12,7 @@ foreach(PROTO_FILE ${PROTO_FILES})
 
     add_custom_command(
         OUTPUT ${PROTO_HDR} ${PROTO_SRC}
-        COMMAND ${PROTOBUF_PROTOC_EXECUTABLE}
+        COMMAND protobuf::protoc
         ARGS --cpp_out=${OUTPUT_DIR} --proto_path ${PROTO_DIR} ${PROTO_FILE}
         DEPENDS ${PROTO_FILE}
         COMMENT "Generating ${PROTO_SRC} and ${PROTO_HDR} from ${PROTO_FILE}"
@@ -25,13 +23,13 @@ foreach(PROTO_FILE ${PROTO_FILES})
     list(APPEND GENERATED_HEADERS ${PROTO_HDR})
 endforeach()
 
-add_library(proof_generatorAssigner STATIC
+add_library(proof_generatorAssigner
             ${PROTO_SRC}
 )
 set_target_properties(proof_generatorAssigner PROPERTIES CXX_STANDARD 20)
 
 target_include_directories(proof_generatorAssigner
-                            PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include ${PROTOBUF_INCLUDE_DIR}
+                            PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/include
 )
 
 find_package(Boost REQUIRED COMPONENTS filesystem log)
@@ -43,11 +41,9 @@ target_link_libraries(proof_generatorAssigner
                         PUBLIC
                         proof_generatorPreset
                         crypto3::common
+                        protobuf::libprotobuf
                         Boost::filesystem
                         Boost::log
-                        absl::strings
-                        absl::log_internal_check_op
-                        ${PROTOBUF_LIBRARY}
 )
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")

--- a/proof-producer/libs/output_artifacts/CMakeLists.txt
+++ b/proof-producer/libs/output_artifacts/CMakeLists.txt
@@ -1,5 +1,4 @@
 add_library(proof_generatorOutputArtifacts 
-    STATIC
     src/output_artifacts.cpp
 )
 

--- a/proof-producer/tests/bin/proof-producer/CMakeLists.txt
+++ b/proof-producer/tests/bin/proof-producer/CMakeLists.txt
@@ -46,6 +46,12 @@ function(add_prover_test target)
         crypto3::common
     )
 
+    if(PROOF_PRODUCER_STATIC_BINARIES)
+        # TODO: try to avoid completely static linking here, it's not necessary, but otherwise build fails for some reason
+        target_link_options(${target}_single_thread PRIVATE -static -static-libgcc -static-libstdc++)
+        target_link_options(${target}_multi_thread PRIVATE -static -static-libgcc -static-libstdc++)
+    endif()
+
     add_dependencies(tests_prover_single_thread ${target}_single_thread)
     add_dependencies(tests_prover_multi_thread ${target}_multi_thread)
 

--- a/proof-producer/tests/libs/output_artifacts/CMakeLists.txt
+++ b/proof-producer/tests/libs/output_artifacts/CMakeLists.txt
@@ -34,6 +34,12 @@ function(add_output_artifacts_test target)
         crypto3::common
     )
 
+    if(PROOF_PRODUCER_STATIC_BINARIES)
+        # TODO: try to avoid completely static linking here, it's not necessary, but otherwise build fails for some reason
+        target_link_options(${target}_single_thread PRIVATE -static -static-libgcc -static-libstdc++)
+        target_link_options(${target}_multi_thread PRIVATE -static -static-libgcc -static-libstdc++)
+    endif()
+
     target_precompile_headers(${target}_single_thread REUSE_FROM proof_generatorOutputArtifacts)
     target_precompile_headers(${target}_multi_thread  REUSE_FROM proof_generatorOutputArtifacts)
 


### PR DESCRIPTION
- Fix protobuf package import to fetch absl dependencies automatically
- Enable building proof-producer binaries as statically linked
- Add bundler to make deb package
- Add package version as a revCount