### PR TITLE
Save assignment description file on fast partial proof

### DIFF
--- a/proof-producer/bin/proof-producer/src/main.cpp
+++ b/proof-producer/bin/proof-producer/src/main.cpp
@@ -130,6 +130,7 @@ int run_prover(const nil::proof_generator::ProverOptions& prover_options) {
                     prover_result =
                         prover.setup_prover() &&
                         prover.fill_assignment_table(prover_options.trace_base_path) &&
+                        prover.save_assignment_description(prover_options.assignment_description_file_path) &&
                         prover.preprocess_public_data() &&
                         prover.save_preprocessed_common_data_to_file(prover_options.preprocessed_common_data_path) &&
                         prover.preprocess_private_data() &&


### PR DESCRIPTION
Fast generate partial proof combines several stages but lacks intermediate output (assignment table description) that is needed for further stages