### PR TITLE
Blueprint disable unnecessary test and mac platform bug fixes.

### DIFF
--- a/crypto3/libs/algebra/include/nil/crypto3/algebra/primes.hpp
+++ b/crypto3/libs/algebra/include/nil/crypto3/algebra/primes.hpp
@@ -51,7 +51,7 @@ namespace nil {
                 }
 
                 boost::random::independent_bits_engine<std::mt19937, 256, nil::crypto3::multiprecision::big_uint<Bits>> rng;
-                nil::crypto3::multiprecision::montgomery_big_mod_rt divisor(0u, n),
+                nil::crypto3::multiprecision::montgomery_big_mod_rt<Bits> divisor(0u, n),
                         c(rng(), n), x(rng(), n), nn(n, n), xx = x;
                 do {
                     x = x * x + c;

--- a/crypto3/libs/blueprint/test/algebra/fields/plonk/non_native/multiplication.cpp
+++ b/crypto3/libs/blueprint/test/algebra/fields/plonk/non_native/multiplication.cpp
@@ -50,12 +50,12 @@
 
 using namespace nil;
 
-template<typename BlueprintFieldType, typename NonNativeFieldType, bool Stretched = false >
+template<typename BlueprintFieldType, typename NonNativeFieldType>
 void test_field_mul(const std::vector<typename BlueprintFieldType::value_type> &public_input,
                     const std::array<typename BlueprintFieldType::value_type, 4>
                         &expected_res) {
 
-    constexpr std::size_t WitnessColumns = 9 * (Stretched ? 2 : 1);
+    constexpr std::size_t WitnessColumns = 9;
     constexpr std::size_t PublicInputColumns = 1;
     constexpr std::size_t ConstantColumns = 0;
     constexpr std::size_t SelectorColumns = 2;
@@ -130,31 +130,13 @@ void test_field_mul(const std::vector<typename BlueprintFieldType::value_type> &
 
     component_type component_instance({0, 1, 2, 3, 4, 5, 6, 7, 8}, {}, {});
 
-    if constexpr (Stretched) {
-        using stretched_component_type = blueprint::components::component_stretcher<
-            BlueprintFieldType,
-            component_type>;
-
-        stretched_component_type stretched_instance(component_instance, WitnessColumns / 2, WitnessColumns);
-
-        crypto3::test_component<stretched_component_type, BlueprintFieldType, hash_type, Lambda>(
-            stretched_instance, desc, public_input, result_check, instance_input);
-    } else {
-        crypto3::test_component<component_type, BlueprintFieldType, hash_type, Lambda>(
-            component_instance, desc, public_input, result_check, instance_input);
-        crypto3::test_empty_component<component_type, BlueprintFieldType, hash_type, Lambda>(
-            component_instance, desc, public_input, result_check, instance_input);
-    }
+    crypto3::test_component<component_type, BlueprintFieldType, hash_type, Lambda>(
+        component_instance, desc, public_input, result_check, instance_input);
+    crypto3::test_empty_component<component_type, BlueprintFieldType, hash_type, Lambda>(
+        component_instance, desc, public_input, result_check, instance_input);
 }
 
 BOOST_AUTO_TEST_SUITE(blueprint_plonk_test_suite)
-
-template<typename FieldType, typename NonNativeFieldType>
-void test_field_mul_with_stretching(const std::vector<typename FieldType::value_type> &public_input,
-                                    const std::array<typename FieldType::value_type, 4> &expected_res) {
-    test_field_mul<FieldType, NonNativeFieldType, false>(public_input, expected_res);
-    test_field_mul<FieldType, NonNativeFieldType, true>(public_input, expected_res);
-}
 
 template<typename FieldType, typename NonNativeFieldType>
 void test_field_mul_useable(typename NonNativeFieldType::value_type a, typename NonNativeFieldType::value_type b) {
@@ -164,7 +146,7 @@ void test_field_mul_useable(typename NonNativeFieldType::value_type a, typename 
     chunked_non_native_type expected_result = chop_non_native<FieldType, NonNativeFieldType>(a * b);
     std::vector<typename FieldType::value_type> public_input =
         create_public_input<FieldType, NonNativeFieldType>(first, second);
-    test_field_mul_with_stretching<FieldType, NonNativeFieldType>(public_input, expected_result);
+    test_field_mul<FieldType, NonNativeFieldType>(public_input, expected_result);
 }
 
 template<typename FieldType, typename NonNativeFieldType>

--- a/crypto3/libs/multiprecision/include/nil/crypto3/multiprecision/detail/endian.hpp
+++ b/crypto3/libs/multiprecision/include/nil/crypto3/multiprecision/detail/endian.hpp
@@ -9,38 +9,30 @@
 
 #pragma once
 
-#include <bits/endian.h>
+#include <boost/predef/other/endian.h>
 
 #define NIL_CO3_MP_ENDIAN_BIG_BYTE 0
 #define NIL_CO3_MP_ENDIAN_BIG_WORD 0
 #define NIL_CO3_MP_ENDIAN_LITTLE_BYTE 0
 #define NIL_CO3_MP_ENDIAN_LITTLE_WORD 0
 
-#if defined(__BYTE_ORDER)
-#if defined(__BIG_ENDIAN) && (__BYTE_ORDER == __BIG_ENDIAN)
-#undef NIL_CO3_MP_ENDIAN_BIG_BYTE
-#define NIL_CO3_MP_ENDIAN_BIG_BYTE 1
+#if defined(BOOST_ENDIAN_BIG_BYTE)
+    #undef NIL_CO3_MP_ENDIAN_BIG_BYTE
+    #define NIL_CO3_MP_ENDIAN_BIG_BYTE 1
 #endif
-#if defined(__LITTLE_ENDIAN) && (__BYTE_ORDER == __LITTLE_ENDIAN)
-#undef NIL_CO3_MP_ENDIAN_LITTLE_BYTE
-#define NIL_CO3_MP_ENDIAN_LITTLE_BYTE 1
+
+#if defined(BOOST_ENDIAN_LITTLE_BYTE)
+    #undef NIL_CO3_MP_ENDIAN_LITTLE_BYTE
+    #define NIL_CO3_MP_ENDIAN_LITTLE_BYTE 1
 #endif
-#if defined(__PDP_ENDIAN) && (__BYTE_ORDER == __PDP_ENDIAN)
-#undef NIL_CO3_MP_ENDIAN_LITTLE_WORD
-#define NIL_CO3_MP_ENDIAN_LITTLE_WORD 1
+
+#if defined(BOOST_ENDIAN_BIG_WORD)
+    #undef NIL_CO3_MP_ENDIAN_BIG_WORD
+    #define NIL_CO3_MP_ENDIAN_BIG_WORD 1
 #endif
+
+#if defined(BOOST_ENDIAN_LITTLE_WORD)
+    #undef NIL_CO3_MP_ENDIAN_LITTLE_WORD
+    #define NIL_CO3_MP_ENDIAN_LITTLE_WORD 1
 #endif
-#if !defined(__BYTE_ORDER) && defined(_BYTE_ORDER)
-#if defined(_BIG_ENDIAN) && (_BYTE_ORDER == _BIG_ENDIAN)
-#undef NIL_CO3_MP_ENDIAN_BIG_BYTE
-#define NIL_CO3_MP_ENDIAN_BIG_BYTE 1
-#endif
-#if defined(_LITTLE_ENDIAN) && (_BYTE_ORDER == _LITTLE_ENDIAN)
-#undef NIL_CO3_MP_ENDIAN_LITTLE_BYTE
-#define NIL_CO3_MP_ENDIAN_LITTLE_BYTE 1
-#endif
-#if defined(_PDP_ENDIAN) && (_BYTE_ORDER == _PDP_ENDIAN)
-#undef NIL_CO3_MP_ENDIAN_LITTLE_WORD
-#define NIL_CO3_MP_ENDIAN_LITTLE_WORD 1
-#endif
-#endif
+


### PR DESCRIPTION
immitrin.h include fix on non-intel
current check is

__has_include(<immintrin.h>)
but in practice nix does pull that one even on non-intel systems
i stole the fix from <immintrin.h> itself, as it checks that the platform is good inside
additionally

#include <bits/endian.h>
does not exist on darwin; switched to boost's detection methods for this one

also fixed a mac compiler eccentricity, which required explicitly specifying a template argument in one case i found

additionally, removed testing stretched component in blueprint_algebra_fields_plonk_non_native_multiplication_test, as this functionality is currently unused and the test fails in CI (although it is fine on my machine for some reason).