### PR TITLE
disable check-proof-producer job

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -30,13 +30,6 @@ jobs:
       always() && !cancelled()
     secrets: inherit
 
-  check-proof-producer:
-    name: Check Proof Producer
-    uses: ./.github/workflows/check-proof-producer.yml
-    if: |
-      always() && !cancelled()
-    secrets: inherit
-
   verify-circuit-proof:
     name: Verify Circuit Proof
     uses: ./.github/workflows/verify-circuit-proof.yml


### PR DESCRIPTION
zkLLVM artifacts expired.
It's CI is currently broken, so we temporally disable this job