### PR TITLE
proof-producer: use proper retcodes

### DIFF
--- a/proof-producer/bin/proof-producer/include/nil/proof-generator/commands/agg_challenge_command.hpp
+++ b/proof-producer/bin/proof-producer/include/nil/proof-generator/commands/agg_challenge_command.hpp
@@ -50,7 +50,7 @@ namespace nil {
                 using ChallengeIO = ChallengeIO<CurveType, HashType>;
 
                 if (aggregate_input_files.empty()) {
-                    return CommandResult::UnknownError("No input files for challenge aggregation");
+                    return CommandResult::Error(ResultCode::InvalidInput, "No input files for challenge aggregation");
                 }
                 BOOST_LOG_TRIVIAL(info) << "Generating aggregated challenge to " << aggregated_challenge_file;
 
@@ -63,7 +63,7 @@ namespace nil {
                 for (const auto &input_file : aggregate_input_files) {
                     std::optional<typename BlueprintField::value_type> challenge = ChallengeIO::read_challenge(input_file);
                     if (!challenge) {
-                        return CommandResult::UnknownError("Failed to read challenge from {}", input_file.string());
+                        return CommandResult::Error(ResultCode::IOError, "Failed to read challenge from {}", input_file.string());
                     }
                     transcript(challenge.value());
                 }
@@ -73,7 +73,7 @@ namespace nil {
 
                 auto const res = ChallengeIO::save_challenge(aggregated_challenge_file, output_challenge);
                 if (!res) {
-                    return CommandResult::UnknownError("Failed to write aggregated challenge to {}", aggregated_challenge_file.string());
+                    return CommandResult::Error(ResultCode::IOError, "Failed to write aggregated challenge to {}", aggregated_challenge_file.string());
                 }
                 return CommandResult::Ok();
             }

--- a/proof-producer/bin/proof-producer/include/nil/proof-generator/commands/aggregated_fri_proof_command.hpp
+++ b/proof-producer/bin/proof-producer/include/nil/proof-generator/commands/aggregated_fri_proof_command.hpp
@@ -112,7 +112,7 @@ namespace nil {
                     std::optional<typename BlueprintField::value_type> aggregated_challenge = ChallengeIO::read_challenge(
                         aggregated_challenge_file);
                     if (!aggregated_challenge) {
-                        return CommandResult::UnknownError("Failed to read aggregated challenge from {}", aggregated_challenge_file.string());
+                        return CommandResult::Error(ResultCode::IOError, "Failed to read aggregated challenge from {}", aggregated_challenge_file.string());
                     }
 
                     // create the transcript
@@ -127,7 +127,7 @@ namespace nil {
                     for (const auto& path : input_combined_Q_polynomial_files) {
                         std::optional<polynomial_type> next_combined_Q = PolynomialIO::read_poly_from_file(path);
                         if (!next_combined_Q) {
-                            return CommandResult::UnknownError("Failed to read next combined Q from {}", path.string());
+                            return CommandResult::Error(ResultCode::IOError, "Failed to read next combined Q from {}", path.string());
                         }
                         sum_poly += next_combined_Q.value();
                     }
@@ -139,17 +139,17 @@ namespace nil {
 
                     auto res = save_fri_proof_to_file(fri_proof, aggregated_fri_proof_output_file);
                     if (!res) {
-                        return CommandResult::UnknownError("Failed to write aggregated FRI proof to file.");
+                        return CommandResult::Error(ResultCode::IOError, "Failed to write aggregated FRI proof to file.");
                     }
 
                     res = save_proof_of_work(proof_of_work, proof_of_work_output_file);
                     if (!res) {
-                        return CommandResult::UnknownError("Failed to write proof of work to file.");
+                        return CommandResult::Error(ResultCode::IOError, "Failed to write proof of work to file.");
                     }
 
                     res = ChallengeIO::save_challenge_vector_to_file(challenges, consistency_checks_challenges_output_file);
                     if (!res) {
-                        return CommandResult::UnknownError("Failed to write consistency checks challenges to file.");
+                        return CommandResult::Error(ResultCode::IOError, "Failed to write consistency checks challenges to file.");
                     }
 
                     return CommandResult::Ok();

--- a/proof-producer/bin/proof-producer/include/nil/proof-generator/commands/compute_combined_q_command.hpp
+++ b/proof-producer/bin/proof-producer/include/nil/proof-generator/commands/compute_combined_q_command.hpp
@@ -68,13 +68,13 @@ namespace nil {
                 std::optional<typename BlueprintField::value_type> challenge = ChallengeIO::read_challenge(
                     aggregated_challenge_file);
                 if (!challenge) {
-                    return CommandResult::UnknownError("Failed to read challenge from {}", aggregated_challenge_file.string());
+                    return CommandResult::Error(ResultCode::IOError, "Failed to read challenge from {}", aggregated_challenge_file.string());
                 }
                 polynomial_type combined_Q = lpc_scheme.prepare_combined_Q(
                     challenge.value(), starting_power);
                 const auto res = PolynomialIO::save_poly_to_file(combined_Q, output_combined_Q_file);
                 if (!res) {
-                    return CommandResult::UnknownError("Failed to write combined Q to {}", output_combined_Q_file.string());
+                    return CommandResult::Error(ResultCode::IOError, "Failed to write combined Q to {}", output_combined_Q_file.string());
                 }
                 return CommandResult::Ok();
             }

--- a/proof-producer/bin/proof-producer/include/nil/proof-generator/commands/detail/io/assignment_table_io.hpp
+++ b/proof-producer/bin/proof-producer/include/nil/proof-generator/commands/detail/io/assignment_table_io.hpp
@@ -45,12 +45,12 @@ namespace nil {
                     BOOST_LOG_TRIVIAL(info) << "Writing binary assignment table to " << output_filename_;
 
                     if (!assignment_table_ || !table_description_) {
-                        return CommandResult::UnknownError("No assignment table is currently loaded");
+                        return CommandResult::Error(ResultCode::ProverError, "No assignment table is currently loaded");
                     }
 
                     std::ofstream out(output_filename_.string(), std::ios::binary | std::ios::out);
                     if (!out.is_open()) {
-                        return CommandResult::UnknownError("Failed to open file {}", output_filename_.string());
+                        return CommandResult::Error(ResultCode::IOError, "Failed to open file {}", output_filename_.string());
                     }
 
                     writer::write_binary_assignment(
@@ -89,7 +89,7 @@ namespace nil {
                         marshalled_assignment_description
                     );
                     if (!res) {
-                        return CommandResult::UnknownError("Failed to write assignment description");
+                        return CommandResult::Error(ResultCode::IOError, "Failed to write assignment description");
                     }
 
                     BOOST_LOG_TRIVIAL(info) << "Assignment description written.";
@@ -118,7 +118,7 @@ namespace nil {
                     BOOST_ASSERT(!opts_.empty());
 
                     if (!assignment_table_ || !table_description_) {
-                        return CommandResult::UnknownError("No assignment table is currently loaded");
+                        return CommandResult::Error(ResultCode::ProverError,"No assignment table is currently loaded");
                     }
 
                     BOOST_LOG_TRIVIAL(debug) << "Rows to print: " << opts_.rows.to_string();
@@ -139,7 +139,7 @@ namespace nil {
                             opts_
                         );
                         if (!res) {
-                            return CommandResult::UnknownError("Failed to write text assignment table");
+                            return CommandResult::Error(ResultCode::IOError, "Failed to write text assignment table");
                         }
                         return CommandResult::Ok();
                     };
@@ -152,7 +152,7 @@ namespace nil {
                     BOOST_LOG_TRIVIAL(info) << "Writing text assignment table to " << opts_.output_filename;
                     std::ofstream out(opts_.output_filename, std::ios::binary | std::ios::out);
                     if (!out.is_open()) {
-                        return CommandResult::UnknownError("Failed to open file {}",  opts_.output_filename);
+                        return CommandResult::Error(ResultCode::IOError, "Failed to open file {}",  opts_.output_filename);
                     }
 
                     return write(out);
@@ -182,7 +182,7 @@ namespace nil {
                     auto marshalled_table =
                         detail::decode_marshalling_from_file<TableMarshalling>(assignment_table_file_path_);
                     if (!marshalled_table) {
-                        return CommandResult::UnknownError("Failed to read assignment table from {}", assignment_table_file_path_.string());
+                        return CommandResult::Error(ResultCode::IOError, "Failed to read assignment table from {}", assignment_table_file_path_.string());
                     }
 
                     auto [table_description, assignment_table] =
@@ -217,7 +217,7 @@ namespace nil {
                     auto marshalled_description =
                         detail::decode_marshalling_from_file<TableDescriptionMarshalling>(assignment_description_file_);
                     if (!marshalled_description) {
-                        return CommandResult::UnknownError("Failed to read assignment description from {}", assignment_description_file_.string());
+                        return CommandResult::Error(ResultCode::IOError, "Failed to read assignment description from {}", assignment_description_file_.string());
                     }
                     auto table_description =
                         nil::crypto3::marshalling::types::make_assignment_table_description<Endianness, BlueprintField>(

--- a/proof-producer/bin/proof-producer/include/nil/proof-generator/commands/detail/io/circuit_io.hpp
+++ b/proof-producer/bin/proof-producer/include/nil/proof-generator/commands/detail/io/circuit_io.hpp
@@ -42,7 +42,7 @@ namespace nil {
 
                     auto marshalled_value = detail::decode_marshalling_from_file<ConstraintMarshalling>(circuit_file_path_);
                     if (!marshalled_value) {
-                        return CommandResult::UnknownError("Failed to read circuit from {}", circuit_file_path_.string());
+                        return CommandResult::Error(ResultCode::IOError, "Failed to read circuit from {}", circuit_file_path_.string());
                     }
                     auto constraint_system = std::make_shared<ConstraintSystem>(
                         nil::crypto3::marshalling::types::make_plonk_constraint_system<Endianness, ZkConstraintSystem>(
@@ -74,12 +74,12 @@ namespace nil {
 
                     BOOST_LOG_TRIVIAL(info) << "Writing circuit to " << circuit_file_path_;
                     if (!constraint_system_) {
-                        return CommandResult::UnknownError("No circuit is currently loaded");
+                        return CommandResult::Error(ResultCode::IOError, "No circuit is currently loaded");
                     }
 
                     std::ofstream out(circuit_file_path_, std::ios::binary | std::ios::out);
                     if (!out.is_open()) {
-                        return CommandResult::UnknownError("Failed to open file {}", circuit_file_path_.string());
+                        return CommandResult::Error(ResultCode::IOError, "Failed to open file {}", circuit_file_path_.string());
                     }
 
                     writer::write_binary_circuit(out, *constraint_system_, constraint_system_->public_input_sizes());

--- a/proof-producer/bin/proof-producer/include/nil/proof-generator/commands/detail/io/lpc_scheme_io.hpp
+++ b/proof-producer/bin/proof-producer/include/nil/proof-generator/commands/detail/io/lpc_scheme_io.hpp
@@ -46,7 +46,7 @@ namespace nil {
                         marshalled_lpc_state
                     );
                     if (!res) {
-                        return CommandResult::UnknownError("Failed to write commitment scheme");
+                        return CommandResult::Error(ResultCode::IOError, "Failed to write commitment scheme");
                     }
 
                     BOOST_LOG_TRIVIAL(info) << "Commitment scheme written.";
@@ -78,12 +78,12 @@ namespace nil {
                         commitment_scheme_state_file_);
 
                     if (!marshalled_value) {
-                        return CommandResult::UnknownError("Failed to read commitment scheme from {}", commitment_scheme_state_file_.string());
+                        return CommandResult::Error(ResultCode::IOError, "Failed to read commitment scheme from {}", commitment_scheme_state_file_.string());
                     }
 
                     auto commitment_scheme = make_commitment_scheme<Endianness, LpcScheme>(*marshalled_value);
                     if (!commitment_scheme) {
-                        return CommandResult::UnknownError("Error decoding commitment scheme");
+                        return CommandResult::Error(ResultCode::InvalidInput, "Error decoding commitment scheme");
                     }
 
                     auto lpc_scheme = std::make_shared<LpcScheme>(std::move(commitment_scheme.value()));

--- a/proof-producer/bin/proof-producer/include/nil/proof-generator/commands/detail/io/preprocessed_data_io.hpp
+++ b/proof-producer/bin/proof-producer/include/nil/proof-generator/commands/detail/io/preprocessed_data_io.hpp
@@ -49,7 +49,7 @@ namespace nil {
                         marshalled_preprocessed_public_data
                     );
                     if (!res) {
-                        return CommandResult::UnknownError("Failed to write preprocessed public data");
+                        return CommandResult::Error(ResultCode::IOError, "Failed to write preprocessed public data");
                     }
                     BOOST_LOG_TRIVIAL(info) << "Preprocessed public data written.";
 
@@ -81,7 +81,7 @@ namespace nil {
                     auto marshalled_value = detail::decode_marshalling_from_file<PublicPreprocessedDataMarshalling>(
                         preprocessed_data_file_);
                     if (!marshalled_value) {
-                        return CommandResult::UnknownError("Failed to read preprocessed data from {}" , preprocessed_data_file_.string());
+                        return CommandResult::Error(ResultCode::IOError, "Failed to read preprocessed data from {}" , preprocessed_data_file_.string());
                     }
 
                     auto public_preprocessed_data = make_placeholder_preprocessed_public_data<Endianness, PublicPreprocessedData>(*marshalled_value);
@@ -118,7 +118,7 @@ namespace nil {
                         marshalled_common_data
                     );
                     if (!res) {
-                        return CommandResult::UnknownError("Failed to write preprocessed common data");
+                        return CommandResult::Error(ResultCode::IOError, "Failed to write preprocessed common data");
                     }
 
                     BOOST_LOG_TRIVIAL(info) << "Preprocessed common data written.";
@@ -148,7 +148,7 @@ namespace nil {
                         preprocessed_common_data_file_);
 
                     if (!marshalled_value) {
-                        return CommandResult::UnknownError("Failed to read preprocessed common data from {}", preprocessed_common_data_file_.string());
+                        return CommandResult::Error(ResultCode::IOError, "Failed to read preprocessed common data from {}", preprocessed_common_data_file_.string());
                     }
 
                     auto common_data = nil::crypto3::marshalling::types::make_placeholder_common_data<Endianness, CommonData>(*marshalled_value);

--- a/proof-producer/bin/proof-producer/include/nil/proof-generator/commands/detail/proof_gen.hpp
+++ b/proof-producer/bin/proof-producer/include/nil/proof-generator/commands/detail/proof_gen.hpp
@@ -77,7 +77,7 @@ namespace nil {
                     BOOST_LOG_TRIVIAL(info) << "Reading proof from file " << proof_file_;
                     auto marshalled_proof = detail::decode_marshalling_from_file<ProofMarshalling>(proof_file_, true);
                     if (!marshalled_proof) {
-                        return CommandResult::UnknownError("Failed to read proof from {}", proof_file_.string());
+                        return CommandResult::Error(ResultCode::IOError, "Failed to read proof from {}", proof_file_.string());
                     }
 
                     notify<Proof>(*this, std::make_shared<Proof>(
@@ -125,7 +125,7 @@ namespace nil {
                     BOOST_ASSERT(this->lpc_scheme_);
 
                     if (!can_write_to_file(proof_file_.string())) {
-                        return CommandResult::UnknownError("Can't write to file {}", proof_file_.string());
+                        return CommandResult::Error(ResultCode::IOError, "Can't write to file {}", proof_file_.string());
                     }
 
                     BOOST_LOG_TRIVIAL(info) << "Generating proof...";
@@ -145,14 +145,14 @@ namespace nil {
 
                     auto res = write_proof_to_file(proof, this->lpc_scheme_->get_fri_params(), proof_file_);
                     if (!res) {
-                        return CommandResult::UnknownError("Failed to write proof to file {}", proof_file_.string());
+                        return CommandResult::Error(ResultCode::IOError, "Failed to write proof to file {}", proof_file_.string());
                     }
 
                     BOOST_LOG_TRIVIAL(info) << "Writing json proof to " << json_file_;
                     auto output_file = open_file<std::ofstream>(json_file_.string(), std::ios_base::out);
                     if (!output_file)
                     {
-                        return CommandResult::UnknownError("Failed to open file {}", json_file_.string());
+                        return CommandResult::Error(ResultCode::IOError, "Failed to open file {}", json_file_.string());
                     }
 
                     using nil::blueprint::recursive_verifier_generator;
@@ -204,7 +204,7 @@ namespace nil {
                     BOOST_ASSERT(this->lpc_scheme_);
 
                     if (!can_write_to_file(proof_file_.string())) {
-                        return CommandResult::UnknownError("Can't write to file {}", proof_file_.string());
+                        return CommandResult::Error(ResultCode::IOError, "Can't write to file {}", proof_file_.string());
                     }
 
                     BOOST_LOG_TRIVIAL(info) << "Generating partial proof...";
@@ -224,7 +224,7 @@ namespace nil {
 
                     auto res = write_proof_to_file(proof, this->lpc_scheme_->get_fri_params(), proof_file_);
                     if (!res) {
-                        return CommandResult::UnknownError("Failed to write proof to file {}", proof_file_.string());
+                        return CommandResult::Error(ResultCode::IOError, "Failed to write proof to file {}", proof_file_.string());
                     }
 
                     BOOST_LOG_TRIVIAL(info) << "Writing challenge to " << challenge_file_ << ".";

--- a/proof-producer/bin/proof-producer/include/nil/proof-generator/commands/fill_assignment_command.hpp
+++ b/proof-producer/bin/proof-producer/include/nil/proof-generator/commands/fill_assignment_command.hpp
@@ -49,16 +49,25 @@ namespace nil {
                     using resources::notify;
 
                     if (!assignment_table_ || !table_description_) {
-                        return CommandResult::UnknownError("Assignment table is not initialized");
+                        return CommandResult::Error(ResultCode::ProverError, "Assignment table is not initialized");
                     }
 
-                    TIME_LOG_START("Fill assignment table")
-                    const auto err = fill_assignment_table_single_thread(*assignment_table_, *table_description_, circuit_name_, trace_base_path_, assigner_opts_);
-                    if (err) {
-                        return CommandResult::UnknownError("Can't fill assignment table from trace '{}', err: {}" , trace_base_path_.string(), err.value());
+                    try {
+                        TIME_LOG_START("Fill assignment table")
+                        const auto err = fill_assignment_table_single_thread(*assignment_table_, *table_description_, circuit_name_, trace_base_path_, assigner_opts_);
+                        if (err) {
+                            return CommandResult::UnknownError("Can't fill assignment table from trace '{}', err: {}" , trace_base_path_.string(), err.value());
+                        }
+                        TIME_LOG_END("Fill assignment table")
+                    } catch (trace_io_error& e) {
+                        return CommandResult::Error(ResultCode::IOError, "Can't read trace file: {}", e.what());
+                    } catch (trace_parse_error& e) {
+                        return CommandResult::Error(ResultCode::InvalidInput, "Can't parse trace file: {}", e.what());
+                    } catch (trace_index_mismatch& e) {
+                        return CommandResult::Error(ResultCode::InvalidInput, "Trace index mismatch: {}", e.what());
+                    } catch (trace_hash_mismatch& e) {
+                        return CommandResult::Error(ResultCode::InvalidInput, "Trace hash mismatch in file err: {}", e.what());
                     }
-                    TIME_LOG_END("Fill assignment table")
-
 
                     notify<AssignmentTable> (*this, assignment_table_);
                     notify<TableDescription>(*this, table_description_);

--- a/proof-producer/bin/proof-producer/include/nil/proof-generator/commands/gen_consistency_check_command.hpp
+++ b/proof-producer/bin/proof-producer/include/nil/proof-generator/commands/gen_consistency_check_command.hpp
@@ -82,17 +82,17 @@ namespace nil {
                 std::optional<std::vector<Challenge>> challenges = ChallengeIO::read_challenge_vector_from_file(
                     consistency_checks_challenges_output_file);
                 if (!challenges)
-                    return CommandResult::UnknownError("Failed to read challenges from {}", consistency_checks_challenges_output_file.string());
+                    return CommandResult::Error(ResultCode::IOError, "Failed to read challenges from {}", consistency_checks_challenges_output_file.string());
 
                 std::optional<polynomial_type> combined_Q = PolynomialIO::read_poly_from_file(combined_Q_file);
                 if (!combined_Q)
-                    return CommandResult::UnknownError("Failed to read combined Q from {}", combined_Q_file.string());
+                    return CommandResult::Error(ResultCode::IOError, "Failed to read combined Q from {}", combined_Q_file.string());
 
                 LpcProofType proof = lpc_scheme->proof_eval_lpc_proof(combined_Q.value(), challenges.value());
 
                 auto const res = save_lpc_consistency_proof_to_file(proof, output_proof_file);
                 if (!res)
-                    return CommandResult::UnknownError("Failed to write proof to file {}", output_proof_file.string());
+                    return CommandResult::Error(ResultCode::IOError, "Failed to write proof to file {}", output_proof_file.string());
 
                 return CommandResult::Ok();
             }

--- a/proof-producer/bin/proof-producer/include/nil/proof-generator/commands/merge_proofs_command.hpp
+++ b/proof-producer/bin/proof-producer/include/nil/proof-generator/commands/merge_proofs_command.hpp
@@ -79,7 +79,7 @@ namespace nil {
                 placeholder_aggregated_proof_type merged_proof;
 
                 if (partial_proof_files.size() != initial_proof_files.size() ) {
-                    return CommandResult::UnknownError("Number of partial and initial proof files should match (got {} vs {})",
+                    return CommandResult::Error(ResultCode::ProverError, "Number of partial and initial proof files should match (got {} vs {})",
                         partial_proof_files.size(), initial_proof_files.size());
                 }
 
@@ -88,7 +88,7 @@ namespace nil {
                     BOOST_LOG_TRIVIAL(info) << "Reading partial proof from file \"" << partial_proof_file << "\"";
                     auto marshalled_partial_proof = detail::decode_marshalling_from_file<partial_proof_marshalled_type>(partial_proof_file, true);
                     if (!marshalled_partial_proof) {
-                        return CommandResult::UnknownError("Error reading partial_proof from from {}", partial_proof_file.string());
+                        return CommandResult::Error(ResultCode::IOError, "Error reading partial_proof from from {}", partial_proof_file.string());
                     }
 
                     partial_proof_type partial_proof = nil::crypto3::marshalling::types::
@@ -103,7 +103,7 @@ namespace nil {
                     auto initial_proof =
                         detail::decode_marshalling_from_file<initial_proof_marshalling_type>(initial_proof_file);
                     if (!initial_proof) {
-                        return CommandResult::UnknownError("Error reading lpc_consistency_proof from from {}", initial_proof_file.string());
+                        return CommandResult::Error(ResultCode::IOError, "Error reading lpc_consistency_proof from from {}", initial_proof_file.string());
                     }
 
                     merged_proof.aggregated_proof.initial_proofs_per_prover.emplace_back(
@@ -116,8 +116,7 @@ namespace nil {
                 auto marshalled_fri_proof = detail::decode_marshalling_from_file<fri_proof_marshalling_type>(aggregated_FRI_file);
 
                 if (!marshalled_fri_proof) {
-                    BOOST_LOG_TRIVIAL(error) << "Error reading fri_proof from \"" << aggregated_FRI_file << "\"";
-                    return CommandResult::UnknownError("Error reading fri_proof from from {}", aggregated_FRI_file.string());
+                    return CommandResult::Error(ResultCode::IOError, "Error reading fri_proof from from {}", aggregated_FRI_file.string());
                 }
                 merged_proof.aggregated_proof.fri_proof =
                     nil::crypto3::marshalling::types::make_initial_fri_proof<Endianness, LpcScheme>(*marshalled_fri_proof);
@@ -129,7 +128,7 @@ namespace nil {
 
                 const auto res = detail::encode_marshalling_to_file<merged_proof_marshalling_type>(merged_proof_file, marshalled_proof);
                 if (!res) {
-                    return CommandResult::UnknownError("Failed to write merged proof to file {}", merged_proof_file.string());
+                    return CommandResult::Error(ResultCode::IOError, "Failed to write merged proof to file {}", merged_proof_file.string());
                 }
 
                 return CommandResult::Ok();

--- a/proof-producer/bin/proof-producer/include/nil/proof-generator/commands/preset_command.hpp
+++ b/proof-producer/bin/proof-producer/include/nil/proof-generator/commands/preset_command.hpp
@@ -59,7 +59,7 @@ namespace nil {
                     TIME_LOG_END("Preset")
 
                     if (err) {
-                        return CommandResult::UnknownError("Can't initialize circuit '{}', err: {}" , circuit_name_, err.value());
+                        return CommandResult::Error(ResultCode::InvalidInput, "Can't initialize circuit '{}', err: {}" , circuit_name_, err.value());
                     }
 
                     notify<ConstraintSystem>(*this, circuit);

--- a/proof-producer/bin/proof-producer/include/nil/proof-generator/commands/verify_command.hpp
+++ b/proof-producer/bin/proof-producer/include/nil/proof-generator/commands/verify_command.hpp
@@ -77,7 +77,7 @@ namespace nil {
                         BOOST_LOG_TRIVIAL(info) << "Proof is verified";
                         return CommandResult::Ok();
                     }
-                    return CommandResult::UnknownError("Proof verification failed");
+                    return CommandResult::Error(ResultCode::ProverError, "Proof verification failed");
                 }
 
             private:

--- a/proof-producer/bin/proof-producer/include/nil/proof-generator/evm_verifier_print.hpp
+++ b/proof-producer/bin/proof-producer/include/nil/proof-generator/evm_verifier_print.hpp
@@ -84,7 +84,7 @@ namespace nil {
                     pi_stream.open(output_folder_.string() + "/public_input.inp");
 
                     if(!pi_stream.is_open()) {
-                        return CommandResult::UnknownError("Can't open file {}/public_input.inp", output_folder_.string());
+                        return CommandResult::Error(ResultCode::IOError, "Can't open file {}/public_input.inp", output_folder_.string());
                     }
 
                     // Does not support public input columns.

--- a/proof-producer/bin/proof-producer/include/nil/proof-generator/resources.hpp
+++ b/proof-producer/bin/proof-producer/include/nil/proof-generator/resources.hpp
@@ -20,16 +20,16 @@ namespace resources {
         resource_provider& operator=(const resource_provider&) = delete;
         resource_provider(resource_provider&&) = default;
         resource_provider& operator=(resource_provider&&) = default;
-        
+
         virtual ~resource_provider() = default;
 
         Signal sig_impl_; // TODO make me private
     };
 
-    template <typename... Resources> 
+    template <typename... Resources>
     class resources_provider: public resource_provider<Resources>... {};
 
-    template <typename T, typename... Resources> 
+    template <typename T, typename... Resources>
     concept ProvidesAll = (std::is_base_of_v<resource_provider<Resources>, T> && ...);
 
     template <typename Resource>
@@ -40,7 +40,7 @@ namespace resources {
     // connects passed slot to the signal of the provider (slot is something invokable with the same signature as the signal)
     template <typename Resource>
     void subscribe(resource_provider<Resource>& provider, const typename resource_provider<Resource>::SlotType& slot) {
-        provider.sig_impl_.connect(slot);  
+        provider.sig_impl_.connect(slot);
     }
 
     // connects passed value (class field usually) to the signal of the provider via lambda
@@ -53,12 +53,12 @@ namespace resources {
 
     template <typename Resource>
     void subscribe_values(
-        resource_provider<Resource>& provider, 
+        resource_provider<Resource>& provider,
         std::initializer_list<
             std::reference_wrapper<
                 typename resource_provider<Resource>::ResourcePtr
             >
-        > resources) 
+        > resources)
     {
         for (auto& resource : resources) {
             subscribe_value(provider, resource);

--- a/proof-producer/libs/assigner/include/nil/proof-generator/assigner/bytecode.hpp
+++ b/proof-producer/libs/assigner/include/nil/proof-generator/assigner/bytecode.hpp
@@ -39,7 +39,7 @@ namespace nil {
             }
 
             const auto keccak_trace_path = get_keccak_trace_path(trace_base_path);
-            const auto keccak_operations = deserialize_keccak_traces_from_file(keccak_trace_path, options);
+            const auto keccak_operations = deserialize_keccak_traces_from_file(keccak_trace_path, options, contract_bytecodes->index);
             if (!keccak_operations) {
                 return "can't read keccak operations from file: " + keccak_trace_path.string();
             }

--- a/proof-producer/libs/assigner/include/nil/proof-generator/assigner/trace_parser.hpp
+++ b/proof-producer/libs/assigner/include/nil/proof-generator/assigner/trace_parser.hpp
@@ -1,14 +1,15 @@
 #ifndef PROOF_GENERATOR_LIBS_ASSIGNER_TRACE_PARSER_HPP_
 #define PROOF_GENERATOR_LIBS_ASSIGNER_TRACE_PARSER_HPP_
 
+#include <stdexcept>
 #include <utility>
 #include <fstream>
 #include <ios>
 #include <optional>
-#include <vector>
 #include <string>
 #include <cstdint>
-#include <unordered_map>
+#include <format>
+
 #include <boost/filesystem.hpp>
 #include <boost/log/trivial.hpp>
 #include <boost/filesystem.hpp>
@@ -26,6 +27,32 @@
 namespace nil {
     namespace proof_producer {
 
+        class trace_hash_mismatch : public std::logic_error {
+        public:
+            explicit trace_hash_mismatch(const std::string& path, const std::string& expectedHash, const std::string& readHash):
+                std::logic_error(std::format("Trace '{}' hash mismatch: expected {}, got {}", path, expectedHash, readHash)) {}
+        };
+
+        class trace_io_error : public std::logic_error {
+        public:
+            explicit trace_io_error(const std::string& path):
+                std::logic_error(std::format("Read '{}' trace io error", path)) {}
+        };
+
+        class trace_parse_error : public std::logic_error {
+        public:
+            explicit trace_parse_error(const std::string& path):
+                std::logic_error(std::format("Parse '{}' trace error", path)) {}
+        };
+
+        class trace_index_mismatch : public std::logic_error {
+        public:
+            explicit trace_index_mismatch(const std::string& path, uint64_t expectedIndex, uint64_t readIndex):
+                std::logic_error(std::format("Trace '{}' index mismatch: expected {}, got {}", path, expectedIndex, readIndex)) {}
+        };
+
+
+
         const char BYTECODE_EXTENSION[] = ".bc";
         const char RW_EXTENSION[] = ".rw";
         const char ZKEVM_EXTENSION[] = ".zkevm";
@@ -33,6 +60,9 @@ namespace nil {
         const char MPT_EXTENSION[] = ".mpt";
         const char EXP_EXTENSION[] = ".exp";
         const char KECCAK_EXTENSION[] = ".keccak";
+
+        using TraceIndex = uint64_t; // value expected to be the same for all traces from the same set
+        using TraceIndexOpt = std::optional<TraceIndex>;
 
         namespace {
             using exp_input = std::pair<blueprint::zkevm_word_type,blueprint::zkevm_word_type>; // base, exponent
@@ -53,23 +83,34 @@ namespace nil {
             }
 
             template<typename ProtoTraces>
-            [[nodiscard]] std::optional<ProtoTraces> read_pb_traces_from_file(const boost::filesystem::path& filename) {
+            [[nodiscard]] ProtoTraces read_pb_traces_from_file(
+                const boost::filesystem::path& filename,
+                TraceIndexOpt index_base,
+                const AssignerOptions& options
+            ) {
                 std::ifstream file(filename.c_str(), std::ios::in | std::ios::binary);
                 if (!file.is_open()) {
-                    return std::nullopt;
+                    throw trace_io_error(filename.string());
                 }
 
                 ProtoTraces pb_traces;
                 if (!pb_traces.ParseFromIstream(&file)) {
-                    return std::nullopt;
+                    throw trace_parse_error(filename.string());
                 }
 
                 if (pb_traces.proto_hash() != PROTO_HASH) {
-                    BOOST_LOG_TRIVIAL(error) << "Compatibility check failed for trace file " << filename.c_str()
-                                             << ": proto version mismatch";
-                    return std::nullopt;
+                    throw trace_hash_mismatch(filename.string(), PROTO_HASH, pb_traces.proto_hash());
 
                 }
+
+                auto index = pb_traces.trace_idx();
+                if (index_base.has_value() && index != *index_base) {
+                    BOOST_LOG_TRIVIAL(warning) << "Trace index mismatch: expected " << *index_base << ", got " << index;
+                    if (!options.ignore_index_mismatch) {
+                        throw trace_index_mismatch(filename.string(), *index_base, index); // TODO: add filename
+                    }
+                }
+
                 return pb_traces;
             }
 
@@ -156,18 +197,6 @@ namespace nil {
             return res;
         }
 
-        using TraceIndex = uint64_t; // value expected to be the same for all traces from the same set
-        using TraceIndexOpt = std::optional<TraceIndex>;
-
-        inline bool check_trace_index(const AssignerOptions& options, TraceIndexOpt base, TraceIndex index) {
-            if (base.has_value() && index != *base) {
-                BOOST_LOG_TRIVIAL(warning) << "Trace index mismatch: expected " << *base << ", got " << index;
-                if (!options.ignore_index_mismatch) {
-                    return false;
-                }
-            }
-            return true;
-        }
 
         template <typename TraceType>
         struct DeserializeResult {
@@ -197,24 +226,18 @@ namespace nil {
             const AssignerOptions& opts,
             TraceIndexOpt base_index = {}
         ) {
-            const auto pb_traces = read_pb_traces_from_file<executionproofs::BytecodeTraces>(bytecode_trace_path);
-            if (!pb_traces) {
-                return std::nullopt;
-            }
-            if (!check_trace_index(opts, base_index, pb_traces->trace_idx())) {
-                return std::nullopt;
-            }
+            const auto pb_traces = read_pb_traces_from_file<executionproofs::BytecodeTraces>(bytecode_trace_path, base_index, opts);
 
             // Read executed op codes
             std::unordered_map<std::string, std::string> contract_bytecodes;
-            const auto& bytecodes = pb_traces->contract_bytecodes();
+            const auto& bytecodes = pb_traces.contract_bytecodes();
             for (const auto& bytecode : bytecodes) {
                 contract_bytecodes.emplace(bytecode.first, bytecode.second);
             }
 
             return DeserializeResult<BytecodeTraces>{
                 std::move(contract_bytecodes),
-                pb_traces->trace_idx()
+                pb_traces.trace_idx()
             };
         }
 
@@ -223,19 +246,13 @@ namespace nil {
             const AssignerOptions& opts,
             TraceIndexOpt base_index = {}
         ) {
-            const auto pb_traces = read_pb_traces_from_file<executionproofs::RWTraces>(rw_traces_path);
-            if (!pb_traces) {
-                return std::nullopt;
-            }
-            if (!check_trace_index(opts, base_index, pb_traces->trace_idx())) {
-                return std::nullopt;
-            }
+            const auto pb_traces = read_pb_traces_from_file<executionproofs::RWTraces>(rw_traces_path, base_index, opts);
 
             blueprint::bbf::rw_operations_vector rw_traces;
-            rw_traces.reserve(pb_traces->stack_ops_size() + pb_traces->memory_ops_size() + pb_traces->storage_ops_size() + 1); // +1 slot for start op
+            rw_traces.reserve(pb_traces.stack_ops_size() + pb_traces.memory_ops_size() + pb_traces.storage_ops_size() + 1); // +1 slot for start op
 
             // Convert stack operations
-            for (const auto& pb_sop : pb_traces->stack_ops()) {
+            for (const auto& pb_sop : pb_traces.stack_ops()) {
                 rw_traces.push_back(blueprint::bbf::stack_rw_operation(
                     static_cast<uint64_t>(pb_sop.txn_id()),
                     static_cast<int32_t>(pb_sop.index()),
@@ -246,7 +263,7 @@ namespace nil {
             }
 
             // Convert memory operations
-            for (const auto& pb_mop : pb_traces->memory_ops()) {
+            for (const auto& pb_mop : pb_traces.memory_ops()) {
                 auto value = string_to_bytes(pb_mop.value());
                 auto const op = blueprint::bbf::memory_rw_operation(
                     static_cast<uint64_t>(pb_mop.txn_id()),
@@ -259,7 +276,7 @@ namespace nil {
             }
 
             // Convert storage operations
-            for (const auto& pb_sop : pb_traces->storage_ops()) {
+            for (const auto& pb_sop : pb_traces.storage_ops()) {
                 auto op = blueprint::bbf::storage_rw_operation(
                     static_cast<uint64_t>(pb_sop.txn_id()),
                     blueprint::zkevm_word_from_string(static_cast<std::string>(pb_sop.key())),
@@ -276,13 +293,13 @@ namespace nil {
             std::sort(rw_traces.begin(), rw_traces.end(), std::less());
 
             BOOST_LOG_TRIVIAL(debug) << "number RW operations " << rw_traces.size() << ":\n"
-                                     << "stack   " << pb_traces->stack_ops_size() << "\n"
-                                     << "memory  " << pb_traces->memory_ops_size() << "\n"
-                                     << "storage " << pb_traces->storage_ops_size() << "\n";
+                                     << "stack   " << pb_traces.stack_ops_size() << "\n"
+                                     << "memory  " << pb_traces.memory_ops_size() << "\n"
+                                     << "storage " << pb_traces.storage_ops_size() << "\n";
 
             return DeserializeResult<RWTraces>{
                 std::move(rw_traces),
-                pb_traces->trace_idx()
+                pb_traces.trace_idx()
             };
         }
 
@@ -291,17 +308,11 @@ namespace nil {
             const AssignerOptions& opts,
             TraceIndexOpt base_index = {}
         ) {
-            const auto pb_traces = read_pb_traces_from_file<executionproofs::ZKEVMTraces>(zkevm_traces_path);
-            if (!pb_traces) {
-                return std::nullopt;
-            }
-            if (!check_trace_index(opts, base_index, pb_traces->trace_idx())) {
-                return std::nullopt;
-            }
+            const auto pb_traces = read_pb_traces_from_file<executionproofs::ZKEVMTraces>(zkevm_traces_path, base_index, opts);
 
             std::vector<blueprint::bbf::zkevm_state> zkevm_states;
-            zkevm_states.reserve(pb_traces->zkevm_states_size());
-            for (const auto& pb_state : pb_traces->zkevm_states()) {
+            zkevm_states.reserve(pb_traces.zkevm_states_size());
+            for (const auto& pb_state : pb_traces.zkevm_states()) {
                 std::vector<blueprint::zkevm_word_type> stack;
                 stack.reserve(pb_state.stack_slice_size());
                 for (const auto& pb_stack_val : pb_state.stack_slice()) {
@@ -331,7 +342,7 @@ namespace nil {
 
             return DeserializeResult<ZKEVMTraces>{
                 std::move(zkevm_states),
-                pb_traces->trace_idx()
+                pb_traces.trace_idx()
             };
         }
 
@@ -340,25 +351,19 @@ namespace nil {
             const AssignerOptions& opts,
             TraceIndexOpt base_index = {}
         ) {
-            const auto pb_traces = read_pb_traces_from_file<executionproofs::CopyTraces>(copy_traces_file);
-            if (!pb_traces) {
-                return std::nullopt;
-            }
-            if (!check_trace_index(opts, base_index, pb_traces->trace_idx())) {
-                return std::nullopt;
-            }
+            const auto pb_traces = read_pb_traces_from_file<executionproofs::CopyTraces>(copy_traces_file, base_index, opts);
 
             namespace bbf = blueprint::bbf;
 
             std::vector<bbf::copy_event> copy_events;
-            copy_events.reserve(pb_traces->copy_events_size());
-            for (const auto& pb_event: pb_traces->copy_events()) {
+            copy_events.reserve(pb_traces.copy_events_size());
+            for (const auto& pb_event: pb_traces.copy_events()) {
                 bbf::copy_event event;
                 event.initial_rw_counter = pb_event.rw_idx();
 
                 const auto source = copy_operand_from_proto(pb_event.from());
                 if (!source) {
-                    return std::nullopt;
+                    throw trace_parse_error(copy_traces_file.string());
                 }
                 event.source_type = source->first;
                 event.source_id = source->second;
@@ -366,7 +371,7 @@ namespace nil {
 
                 const auto dest = copy_operand_from_proto(pb_event.to());
                 if (!dest) {
-                    return std::nullopt;
+                    throw trace_parse_error(copy_traces_file.string());
                 }
                 event.destination_type = dest->first;
                 event.destination_id = dest->second;
@@ -380,7 +385,7 @@ namespace nil {
 
             return DeserializeResult<CopyEvents>{
                 std::move(copy_events),
-                pb_traces->trace_idx()
+                pb_traces.trace_idx()
             };
         }
 
@@ -389,17 +394,11 @@ namespace nil {
             const AssignerOptions& opts,
             TraceIndexOpt base_index = {}
         ) {
-            const auto pb_traces = read_pb_traces_from_file<executionproofs::ExpTraces>(exp_traces_path);
-            if (!pb_traces) {
-                return std::nullopt;
-            }
-            if (!check_trace_index(opts, base_index, pb_traces->trace_idx())) {
-                return std::nullopt;
-            }
+            const auto pb_traces = read_pb_traces_from_file<executionproofs::ExpTraces>(exp_traces_path, base_index, opts);
 
             std::vector<exp_input> exps;
-            exps.reserve(pb_traces->exp_ops_size());
-            for (const auto& pb_exp_op : pb_traces->exp_ops()) {
+            exps.reserve(pb_traces.exp_ops_size());
+            for (const auto& pb_exp_op : pb_traces.exp_ops()) {
                 exps.emplace_back(
                     proto_uint256_to_zkevm_word(pb_exp_op.base()),
                     proto_uint256_to_zkevm_word(pb_exp_op.exponent())
@@ -408,7 +407,7 @@ namespace nil {
 
             return DeserializeResult<ExpTraces>{
                 std::move(exps),
-                pb_traces->trace_idx()
+                pb_traces.trace_idx()
             };
         }
 
@@ -417,17 +416,11 @@ namespace nil {
             const AssignerOptions& opts,
             TraceIndexOpt base_index = {}
         ) {
-            const auto pb_traces = read_pb_traces_from_file<executionproofs::KeccakTraces>(keccak_traces_path);
-            if (!pb_traces) {
-                return std::nullopt;
-            }
-            if (!check_trace_index(opts, base_index, pb_traces->trace_idx())) {
-                return std::nullopt;
-            }
+            const auto pb_traces = read_pb_traces_from_file<executionproofs::KeccakTraces>(keccak_traces_path, base_index, opts);
 
             KeccakTraces result;
-            result.reserve(pb_traces->hashed_buffers_size());
-            for (const auto& pb_hashed_buffer: pb_traces->hashed_buffers()) {
+            result.reserve(pb_traces.hashed_buffers_size());
+            for (const auto& pb_hashed_buffer: pb_traces.hashed_buffers()) {
                 result.push_back(keccak_input{
                     .buffer = string_to_bytes(pb_hashed_buffer.buffer()),
                     .hash =proto_uint256_to_zkevm_word(pb_hashed_buffer.keccak_hash())
@@ -436,7 +429,7 @@ namespace nil {
 
             return DeserializeResult<KeccakTraces>{
                 .value = std::move(result),
-                .index = pb_traces->trace_idx()
+                .index = pb_traces.trace_idx()
             };
         }
     } // namespace proof_producer

--- a/proof-producer/tests/bin/proof-producer/test_zkevm_bbf_circuits.cpp
+++ b/proof-producer/tests/bin/proof-producer/test_zkevm_bbf_circuits.cpp
@@ -112,7 +112,7 @@ TEST(ProverTest, TraceIndexMismatch) {
 
     ProverTests::AssignmentTableChecker checker(ZKEVM, trace_base_path);
     auto const res = checker.execute();
-    ASSERT_FALSE(res.succeeded());
+    ASSERT_EQ(res.result_code(), nil::proof_producer::ResultCode::InvalidInput);
     ASSERT_NE(checker.circuit_, nullptr);        // circuit is filled
     ASSERT_EQ(checker.assignment_table_, nullptr); // assignment table is not filled
 }
@@ -123,7 +123,7 @@ TEST(ProverTest, DifferentProtoHash) {
 
     ProverTests::AssignmentTableChecker checker(ZKEVM, trace_base_path);
     auto const res = checker.execute();
-    ASSERT_FALSE(res.succeeded());
+    ASSERT_EQ(res.result_code(), nil::proof_producer::ResultCode::InvalidInput);
     ASSERT_NE(checker.circuit_, nullptr);        // circuit is filled
     ASSERT_EQ(checker.assignment_table_, nullptr); // assignment table is not filled
 }


### PR DESCRIPTION
- Added separate OutOfMemory error and mapped it to std::bad_alloc
- Wrapped all IO errors with input/output artifacts operations
- Moved to exceptions in assigner trace parser in order to make a difference between IO errors and malformed or inconsistent traces
- Wrapped all `std::logic_error`  exceptions from crypto3 with ProverError
- Added retcode check to the proof producer tests