### PR TITLE
limit gcc build by 12 cores

### DIFF
--- a/.github/workflows/clang-sanitizers-linux-nix-check.yml
+++ b/.github/workflows/clang-sanitizers-linux-nix-check.yml
@@ -25,7 +25,7 @@ jobs:
           cp result/test-logs/*_test.xml results/
         env:
           NIX_CONFIG: |
-            cores = 16
+            cores = 12
 
       - name: Publish Test Results
         uses: EnricoMi/publish-unit-test-result-action/linux@v2

--- a/.github/workflows/gcc-linux-nix-check.yml
+++ b/.github/workflows/gcc-linux-nix-check.yml
@@ -22,7 +22,7 @@ jobs:
           nix build -L .?#checks.x86_64-linux.crypto3-gcc
         env:
           NIX_CONFIG: |
-            cores = 16
+            cores = 12
       - name: Run all checks
         # This includes cached crypto3 check from previous step. We don't limit cores in this part
         run: |


### PR DESCRIPTION
We experience OOM on GCC build. Limit the cores number to have the build more robust.