### PR TITLE
Add test real signature for ECDSA test

### DIFF
--- a/crypto3/libs/blueprint/include/nil/blueprint/bbf/components/pubkey/ecdsa/ecdsa_recovery.hpp
+++ b/crypto3/libs/blueprint/include/nil/blueprint/bbf/components/pubkey/ecdsa/ecdsa_recovery.hpp
@@ -39,6 +39,7 @@
 #include <nil/blueprint/bbf/generic.hpp>
 #include <nil/crypto3/algebra/curves/pallas.hpp>
 #include <nil/crypto3/algebra/curves/vesta.hpp>
+#include <nil/crypto3/algebra/curves/secp_k1.hpp>
 
 namespace nil {
     namespace blueprint {
@@ -467,7 +468,7 @@ namespace nil {
                                     ? (x1 * x1 * x1 + a).sqrt()
                                     : 1;  // should be signaled as invalid signaure
                             if (base_basic_integral_type(y1.data) % 2 !=
-                                scalar_basic_integral_type(V.data) % 2) {
+                                scalar_basic_integral_type(integral_type(V.data)) % 2) {
                                 y1 = -y1;
                             }
                             C[5] = (x1 * x1 * x1 + a - y1 * y1).is_zero();
@@ -485,10 +486,10 @@ namespace nil {
                                           .inversed();
 
                             C[7] = ((base_basic_integral_type(y1.data) % 2) ==
-                                    (scalar_basic_integral_type(V.data) % 2));
+                                    (scalar_basic_integral_type(integral_type(V.data)) % 2));
                             d2 = (base_basic_integral_type(y1.data) +
                                   base_basic_integral_type(
-                                      scalar_basic_integral_type(V.data))) /
+                                      scalar_basic_integral_type(integral_type(V.data)))) /
                                  2;
 
                             SCALAR_TYPE
@@ -752,6 +753,17 @@ namespace nil {
                                             crypto3::algebra::curves::vesta> {
                     using Base =
                         ecdsa_recovery<FieldType, stage, crypto3::algebra::curves::vesta>;
+
+                  public:
+                    using Base::Base;
+                };
+
+                template<typename FieldType, GenerationStage stage>
+                class secp_k1_256_ecdsa_recovery
+                    : public ecdsa_recovery<FieldType, stage,
+                                            crypto3::algebra::curves::secp_k1<256>> {
+                    using Base =
+                        ecdsa_recovery<FieldType, stage, crypto3::algebra::curves::secp_k1<256>>;
 
                   public:
                     using Base::Base;


### PR DESCRIPTION
Add one more test case to `blueprint_bbf_pubkey_ecdsa_ecdsa_recovery_test` which used value of the real signature
```
z = 0x0a0a207c037b61815ce0d1fd1be660806002b16ce4b714fe7ff5f3f929324c5b
r = 0xcf03d98f88bb7c12d9c73212891852dd7b4bc0681f1f7d77d0098ebf3627c6
s = 0x47d6ecfa1eebf313349c9c79d53342b0fc42939c7e10556ee97296c00b3eee
v = 0x01

QA.X = 0x3059732f1ab47f8e34a1919cf621f074d479722dcd0c63dd5d3100dd1372bd1c
QA.Y = 0xdd6003a72e6ba49073e2286c645acf5d93417b1c3c7a0fda81246469ae3b7f2f
```