### PR TITLE
fix link usage.md

### DIFF
--- a/crypto3/libs/blueprint/docs/usage.md
+++ b/crypto3/libs/blueprint/docs/usage.md
@@ -437,7 +437,7 @@ zk-SNARK verifier argument has to contain of 3 parts packed together:
 * `primary_input_type primary_input`
 * `proof_type proof`
 
-Type requirements for those are described in the [Groth16 zk-SNARK policy](https://github.com/NilFoundation/crypto3-zk/blob/master/include/nil/crypto3/zk/snark/schemes/ppzksnark/r1cs_gg_ppzksnark.hpp)
+Type requirements for those are described in the [Groth16 zk-SNARK policy](https://github.com/NilFoundation/zkllvm-blueprint/blob/master/test/basic_components_r1cs_gg_ppzksnark.cpp)
 
 Byte vector assumes to be byte representation of all the underlying data types, 
 recursively unwrapped to Fp field element and integral `std::size_t` values. 


### PR DESCRIPTION
https://github.com/NilFoundation/crypto3-zk/blob/master/include/nil/crypto3/zk/snark/schemes/ppzksnark/r1cs_gg_ppzksnark.hpp - non `work link `

https://github.com/NilFoundation/zkllvm-blueprint/blob/master/test/basic_components_r1cs_gg_ppzksnark.cpp
`work link`