### PR TITLE
ci: bump actions/checkout to v4

### DIFF
--- a/.github/workflows/clang-linux-nix-check.yml
+++ b/.github/workflows/clang-linux-nix-check.yml
@@ -13,7 +13,7 @@ jobs:
         run: chmod +w -R ${GITHUB_WORKSPACE}; rm -rf ${GITHUB_WORKSPACE}/*;
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/clang-sanitizers-linux-nix-check.yml
+++ b/.github/workflows/clang-sanitizers-linux-nix-check.yml
@@ -14,7 +14,7 @@ jobs:
         run: chmod +w -R ${GITHUB_WORKSPACE}; rm -rf ${GITHUB_WORKSPACE}/*;
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/gcc-debug-proof-producer-nix-check.yml
+++ b/.github/workflows/gcc-debug-proof-producer-nix-check.yml
@@ -13,7 +13,7 @@ jobs:
         run: chmod +w -R ${GITHUB_WORKSPACE}; rm -rf ${GITHUB_WORKSPACE}/*;
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/gcc-linux-nix-check.yml
+++ b/.github/workflows/gcc-linux-nix-check.yml
@@ -13,7 +13,7 @@ jobs:
         run: chmod +w -R ${GITHUB_WORKSPACE}; rm -rf ${GITHUB_WORKSPACE}/*;
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -33,7 +33,7 @@ jobs:
       - test-linux-sanitizers
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 

--- a/.github/workflows/verify-hardhat-proofs.yml
+++ b/.github/workflows/verify-hardhat-proofs.yml
@@ -13,7 +13,7 @@ jobs:
         run: chmod +w -R ${GITHUB_WORKSPACE}; rm -rf ${GITHUB_WORKSPACE}/*;
 
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
Hey ! GitHub‑hosted runners now use Node 20, so checkout v4 is required
This PR updates all workflows to actions/checkout@v4 , no functional changes expected