### PR TITLE
SHR opcode circuit adapted for small fields

### DIFF
--- a/crypto3/libs/blueprint/include/nil/blueprint/zkevm_bbf/opcodes/sar.hpp
+++ b/crypto3/libs/blueprint/include/nil/blueprint/zkevm_bbf/opcodes/sar.hpp
@@ -1,6 +1,9 @@
 //---------------------------------------------------------------------------//
 // Copyright (c) 2024 Alexey Yashunsky <a.yashunsky@nil.foundation>
 // Copyright (c) 2024 Antoine Cyr <antoine.cyr@nil.foundation>
+// Copyright (c) 2025 Maxim Nikolaev <maksim.n@nil.foundation
+// Copyright (c) 2025 Javier Silva <javier.silva@nil.foundation>
+
 //
 // MIT License
 //

--- a/crypto3/libs/blueprint/include/nil/blueprint/zkevm_bbf/opcodes/shr.hpp
+++ b/crypto3/libs/blueprint/include/nil/blueprint/zkevm_bbf/opcodes/shr.hpp
@@ -1,6 +1,7 @@
 //---------------------------------------------------------------------------//
 // Copyright (c) 2024 Alexey Yashunsky <a.yashunsky@nil.foundation>
 // Copyright (c) 2024 Antoine Cyr <antoine.cyr@nil.foundation>
+// Copyright (c) 2025 Javier Silva <javier.silva@nil.foundation>
 //
 // MIT License
 //


### PR DESCRIPTION
Basically the same changes as in the SAR circuit, except for the sign extension part.

In the case of a large shift, we simply set 0 as the result. 