### PR TITLE
SHL opcode circuit adapted for small fields 

### DIFF
--- a/crypto3/libs/blueprint/include/nil/blueprint/zkevm_bbf/opcodes/sar.hpp
+++ b/crypto3/libs/blueprint/include/nil/blueprint/zkevm_bbf/opcodes/sar.hpp
@@ -260,7 +260,6 @@ class zkevm_sar_bbf : public generic_component<FieldType, stage> {
                 mul8_chunks[i] = (mul8_carryless_chunks[i] + prev_carry).to_integral() & mask8;
                 mul8_carries[i] = (mul8_carryless_chunks[i] + prev_carry).to_integral() >> 8;
                 BOOST_ASSERT(mul8_carryless_chunks[i] + prev_carry == mul8_chunks[i] + 256 * mul8_carries[i]);
-
             }
             allocate(mul8_chunks[i], i, 3);
             mul8_chunk_check[i] = mul8_chunks[i] * 256;
@@ -394,7 +393,7 @@ class zkevm_sar_bbf : public generic_component<FieldType, stage> {
         // We will place this in the correct chunk to recover b == 2^(shift_value)
         shift_lower_power = 0;
         unsigned int pow = 1;
-        // shift_power == 2^(shift_lower)
+        // shift_lower_power == 2^(shift_lower)
         for (std::size_t i = 0; i < chunk_amount; i++) {
             shift_lower_power += (1 - (shift_lower - i) * indic_1[i]) * pow;
             pow *= 2;
@@ -404,8 +403,8 @@ class zkevm_sar_bbf : public generic_component<FieldType, stage> {
         // connection between b_chunks and input_b_chunks (implicitly via shift_lower & shift_upper)
         // Recall that b is the actual shift performed, in power-of-2 form.
         for (std::size_t i = 0; i < chunk_amount; i++) {
-            // b_chunks[i] == shift_power * (1 - (shift_upper - i) * indic_2[i])
-            // shift_upper == i  <=>  b_chunks[i] == shift_power == 2^(shift_lower)
+            // b_chunks[i] == shift_lower_power * (1 - (shift_upper - i) * indic_2[i])
+            // shift_upper == i  <=>  b_chunks[i] == shift_lower_power == 2^(shift_lower)
             // shift_upper != i  <=>  b_chunks[i] == 0
             constrain(b_chunks_copy2[i] - shift_lower_power * (1 - (shift_upper - i) * indic_2[i]));
         }
@@ -416,7 +415,7 @@ class zkevm_sar_bbf : public generic_component<FieldType, stage> {
         // shift_upper == 10
         // indic_1[7]  == 0, and indic_1[i] == (shift_lower - 7)^(-1)  for all other i.
         // indic_2[10] == 0, and indic_2[i] == (shift_upper - 10)^(-1) for all other i.
-        // shift_power == 2^7
+        // shift_lower_power == 2^7
         // b_chunks[10] == 2^7, and b_chunks[i] = 0 for all other i.
         // That is, b == 2^7..(followed by 10 chunks of 16 zeros) == 2^7 * 2^(10*16) == 2^167.
 

--- a/crypto3/libs/blueprint/include/nil/blueprint/zkevm_bbf/opcodes/shl.hpp
+++ b/crypto3/libs/blueprint/include/nil/blueprint/zkevm_bbf/opcodes/shl.hpp
@@ -1,6 +1,7 @@
 //---------------------------------------------------------------------------//
 // Copyright (c) 2024 Alexey Yashunsky <a.yashunsky@nil.foundation>
 // Copyright (c) 2024 Antoine Cyr <antoine.cyr@nil.foundation>
+// Copyright (c) 2025 Javier Silva <javier.silva@nil.foundation>
 //
 // MIT License
 //

--- a/crypto3/libs/blueprint/include/nil/blueprint/zkevm_bbf/opcodes/shl.hpp
+++ b/crypto3/libs/blueprint/include/nil/blueprint/zkevm_bbf/opcodes/shl.hpp
@@ -99,18 +99,18 @@ namespace nil {
                     TYPE first_carryless;
                     TYPE second_carryless;
 
-                    TYPE b0p;
-                    TYPE b0pp;
-                    TYPE b0ppp;
+                    TYPE b0p;           // lowest 4 bits of input_b
+                    TYPE b0pp;          // next 4 bits of input_b
+                    TYPE b0ppp;         // next 8 bits of input_b
                     TYPE b0p_range_check;
                     TYPE b0pp_range_check;
                     TYPE b0ppp_range_check;
-                    TYPE I1;
-                    TYPE I2;
-                    TYPE z;
-                    TYPE tp;
-                    TYPE two_powers;
-                    TYPE sum_b;
+                    TYPE I1;            // inverse of b0ppp (bits 8-15 of input_b)
+                    TYPE I2;            // inverse of sum_b
+                    TYPE z;             // indicator for large shift
+                    TYPE tp;            // z * 2^b0p
+                    TYPE two_powers;    // 2^b0p
+                    TYPE sum_b;         // sum of chunks of input_b, except for the first
 
                     std::vector<TYPE> a_64_chunks(4);
                     std::vector<TYPE> b_64_chunks(4);
@@ -143,6 +143,7 @@ namespace nil {
                         zkevm_word_type result = a << shift;
 
                         zkevm_word_type b = zkevm_word_type(1) << shift;
+                        // r == a * b
 
                         input_b_chunks = zkevm_word_to_field_element<FieldType>(input_b);
                         a_chunks = zkevm_word_to_field_element<FieldType>(a);

--- a/crypto3/libs/blueprint/include/nil/blueprint/zkevm_bbf/opcodes/shr.hpp
+++ b/crypto3/libs/blueprint/include/nil/blueprint/zkevm_bbf/opcodes/shr.hpp
@@ -250,7 +250,6 @@ class zkevm_shr_bbf : public generic_component<FieldType, stage> {
                 mul8_chunks[i] = (mul8_carryless_chunks[i] + prev_carry).to_integral() & mask8;
                 mul8_carries[i] = (mul8_carryless_chunks[i] + prev_carry).to_integral() >> 8; 
                 BOOST_ASSERT(mul8_carryless_chunks[i] + prev_carry == mul8_chunks[i] + 256 * mul8_carries[i]);
-                
             }
             allocate(mul8_chunks[i], i, 3);
             mul8_chunk_check[i] = mul8_chunks[i] * 256;
@@ -384,7 +383,7 @@ class zkevm_shr_bbf : public generic_component<FieldType, stage> {
         // We will place this in the correct chunk to recover b == 2^(shift_value)
         shift_lower_power = 0;
         unsigned int pow = 1;
-        // shift_power == 2^(shift_lower)
+        // shift_lower_power == 2^(shift_lower)
         for (std::size_t i = 0; i < chunk_amount; i++) {
             shift_lower_power += (1 - (shift_lower - i) * indic_1[i]) * pow;
             pow *= 2;
@@ -394,8 +393,8 @@ class zkevm_shr_bbf : public generic_component<FieldType, stage> {
         // connection between b_chunks and input_b_chunks (implicitly via shift_lower & shift_upper)
         // Recall that b is the actual shift performed, in power-of-2 form.
         for (std::size_t i = 0; i < chunk_amount; i++) {
-            // b_chunks[i] == shift_power * (1 - (shift_upper - i) * indic_2[i]) 
-            // shift_upper == i  <=>  b_chunks[i] == shift_power == 2^(shift_lower)
+            // b_chunks[i] == shift_lower_power * (1 - (shift_upper - i) * indic_2[i]) 
+            // shift_upper == i  <=>  b_chunks[i] == shift_lower_power == 2^(shift_lower)
             // shift_upper != i  <=>  b_chunks[i] == 0
             constrain(b_chunks_copy2[i] - shift_lower_power * (1 - (shift_upper - i) * indic_2[i]));
         }
@@ -406,7 +405,7 @@ class zkevm_shr_bbf : public generic_component<FieldType, stage> {
         // shift_upper == 10
         // indic_1[7]  == 0, and indic_1[i] == (shift_lower - 7)^(-1)  for all other i.
         // indic_2[10] == 0, and indic_2[i] == (shift_upper - 10)^(-1) for all other i.
-        // shift_power == 2^7 
+        // shift_lower_power == 2^7 
         // b_chunks[10] == 2^7, and b_chunks[i] = 0 for all other i.
         // That is, b == 2^7..(followed by 10 chunks of 16 zeros) == 2^7 * 2^(10*16) == 2^167.
 

--- a/crypto3/libs/blueprint/include/nil/blueprint/zkevm_bbf/opcodes/shr.hpp
+++ b/crypto3/libs/blueprint/include/nil/blueprint/zkevm_bbf/opcodes/shr.hpp
@@ -123,7 +123,6 @@ class zkevm_shr_bbf : public generic_component<FieldType, stage> {
         std::vector<TYPE> b8_chunks(chunk_8_amount);        // Shift power in 8-bit chunks
         std::vector<TYPE> b8_chunks_check(chunk_8_amount);  // Range check for b8_chunks
         std::vector<TYPE> add_carries(chunk_amount - 1);    // Carries for v + b
-        TYPE a_chunks15_copy1;                              // Copy of a_chunks[15]
 
         std::vector<TYPE> mul8_carryless_chunks(chunk_8_amount);        // carryless terms of r*b with coefficients 2^(8*i), 0 <= i < 32
         std::vector<TYPE> mul8_carryless_chunks_high(chunk_8_amount);   // carryless terms of r*b with coefficients 2^(8*i), 32 <= i < 62 (i = 62 and i = 63 are zero anyway)
@@ -174,7 +173,6 @@ class zkevm_shr_bbf : public generic_component<FieldType, stage> {
             // Convert to field elements
             input_b_chunks = zkevm_word_to_field_element<FieldType>(input_b);
             a_chunks = zkevm_word_to_field_element<FieldType>(a);
-            a_chunks15_copy1 = a_chunks[15];
             b_chunks = zkevm_word_to_field_element<FieldType>(b);
             b_chunks_copy1 = zkevm_word_to_field_element<FieldType>(b);
             b_chunks_copy2 = zkevm_word_to_field_element<FieldType>(b);
@@ -219,8 +217,6 @@ class zkevm_shr_bbf : public generic_component<FieldType, stage> {
             constrain(b_chunks[i] - b_chunks_copy1[i]);
             constrain(b_chunks_copy1[i] - b_chunks_copy2[i]);
         }
-        allocate(a_chunks15_copy1, 15, 7);
-        constrain(a_chunks[15] - a_chunks15_copy1);
 
         for (std::size_t i = 0; i < chunk_8_amount; i++) {
             allocate(b8_chunks[i], i, 2);

--- a/crypto3/libs/blueprint/test/zkevm_bbf/opcodes/byte_ops.cpp
+++ b/crypto3/libs/blueprint/test/zkevm_bbf/opcodes/byte_ops.cpp
@@ -181,6 +181,11 @@ BOOST_AUTO_TEST_CASE(byte_ops) {
     opcode_tester.push_opcode(
         zkevm_opcode::PUSH32,
         0x8b70726fb8d3a24da9ff9647225a18412b8f010425938504d73ebc8801e2e016_big_uint256);
+    opcode_tester.push_opcode(zkevm_opcode::PUSH32,256);
+    opcode_tester.push_opcode(zkevm_opcode::SHL);
+    opcode_tester.push_opcode(
+        zkevm_opcode::PUSH32,
+        0x8b70726fb8d3a24da9ff9647225a18412b8f010425938504d73ebc8801e2e016_big_uint256);
     opcode_tester.push_opcode(zkevm_opcode::PUSH32,257);
     opcode_tester.push_opcode(zkevm_opcode::SAR);
     opcode_tester.push_opcode(


### PR DESCRIPTION
Slightly different from the SAR and SHR opcodes (the SHL circuit is smaller), but still reusing most of the same logic. Also, I made small corrections in previous opcodes:
- fixed an error in a comment in SAR and SHR.
- removed an unnecessary value from SHR (it was a leftover from the SAR code, it was allocated but never constrained).