### PR TITLE
Clean the code of LPC, use addition point _etha much easier. Don't convert committed polynomials to coefficients form twice. Allow committing to polynomials only in DFS form in LPC.

### DIFF
--- a/crypto3/libs/blueprint/test/verifiers/placeholder/dfri_input_generator.cpp
+++ b/crypto3/libs/blueprint/test/verifiers/placeholder/dfri_input_generator.cpp
@@ -304,11 +304,12 @@ BOOST_FIXTURE_TEST_CASE(lpc_basic_test, test_fixture) {
     typedef hashes::poseidon<nil::crypto3::hashes::detail::pasta_poseidon_policy<FieldType>> merkle_hash_type;
     typedef hashes::poseidon<nil::crypto3::hashes::detail::pasta_poseidon_policy<FieldType>> transcript_hash_type;
     typedef typename containers::merkle_tree<merkle_hash_type, 2> merkle_tree_type;
+    typedef typename math::polynomial_dfs<typename FieldType::value_type> poly_type;
 
     constexpr static const std::size_t lambda = 10;
     constexpr static const std::size_t k = 1;
 
-    constexpr static const std::size_t d = 16;
+    constexpr static const std::size_t d = 15;
     constexpr static const std::size_t r = boost::static_log2<(d - k)>::value;
 
     constexpr static const std::size_t m = 2;
@@ -340,20 +341,20 @@ BOOST_FIXTURE_TEST_CASE(lpc_basic_test, test_fixture) {
                                               12       // grinding_parameter
     );
 
-    using lpc_scheme_type =
-        nil::crypto3::zk::commitments::lpc_commitment_scheme<lpc_type,
-                                                             math::polynomial<typename FieldType::value_type>>;
+    using lpc_scheme_type = nil::crypto3::zk::commitments::lpc_commitment_scheme<
+        lpc_type, poly_type>;
+
     lpc_scheme_type lpc_scheme_prover(fri_params);
     lpc_scheme_type lpc_scheme_verifier(fri_params);
 
     // Generate polynomials
-    lpc_scheme_prover.append_to_batch(0, {1u, 13u, 4u, 1u, 5u, 6u, 7u, 2u, 8u, 7u, 5u, 6u, 1u, 2u, 1u, 1u});
-    lpc_scheme_prover.append_to_batch(1, {0u, 1u});
-    lpc_scheme_prover.append_to_batch(1, {0u, 1u, 2u});
-    lpc_scheme_prover.append_to_batch(1, {0u, 1u, 3u});
-    lpc_scheme_prover.append_to_batch(2, {0u});
-    lpc_scheme_prover.append_to_batch(3, generate_random_polynomial(4, test_global_alg_rnd_engine<FieldType>));
-    lpc_scheme_prover.append_to_batch(3, generate_random_polynomial(9, test_global_alg_rnd_engine<FieldType>));
+    lpc_scheme_prover.append_to_batch(0, poly_type(15, {1u, 13u, 4u, 1u, 5u, 6u, 7u, 2u, 8u, 7u, 5u, 6u, 1u, 2u, 1u, 1u}));
+    lpc_scheme_prover.append_to_batch(1, poly_type(1, {0u, 1u}));
+    lpc_scheme_prover.append_to_batch(1, poly_type(2, {0u, 1u, 2u, 3u}));
+    lpc_scheme_prover.append_to_batch(1, poly_type(2, {0u, 1u, 3u, 4u}));
+    lpc_scheme_prover.append_to_batch(2, poly_type(0, {0u}));
+    lpc_scheme_prover.append_to_batch(3, generate_random_polynomial_dfs(3, test_global_alg_rnd_engine<FieldType>));
+    lpc_scheme_prover.append_to_batch(3, generate_random_polynomial_dfs(7, test_global_alg_rnd_engine<FieldType>));
 
     // Commit
     std::map<std::size_t, typename lpc_type::commitment_type> commitments;
@@ -429,7 +430,7 @@ BOOST_FIXTURE_TEST_CASE(lpc_basic_test, test_fixture) {
     //     constexpr static const std::size_t lambda = 10;
     //     constexpr static const std::size_t k = 1;
 
-    //     constexpr static const std::size_t d = 2048;
+    //     constexpr static const std::size_t d = 2047;
 
     //     constexpr static const std::size_t r = boost::static_log2<(d - k)>::value;
     //     constexpr static const std::size_t m = 2;
@@ -536,7 +537,7 @@ BOOST_FIXTURE_TEST_CASE(lpc_basic_test, test_fixture) {
     //     constexpr static const std::size_t lambda = 10;
     //     constexpr static const std::size_t k = 1;
 
-    //     constexpr static const std::size_t d = 16;
+    //     constexpr static const std::size_t d = 15;
 
     //     constexpr static const std::size_t r = boost::static_log2<(d - k)>::value;
     //     constexpr static const std::size_t m = 2;

--- a/crypto3/libs/blueprint/test/verifiers/placeholder/dfri_input_generator.cpp
+++ b/crypto3/libs/blueprint/test/verifiers/placeholder/dfri_input_generator.cpp
@@ -352,7 +352,7 @@ BOOST_FIXTURE_TEST_CASE(lpc_basic_test, test_fixture) {
     lpc_scheme_prover.append_to_batch(1, poly_type(1, {0u, 1u}));
     lpc_scheme_prover.append_to_batch(1, poly_type(2, {0u, 1u, 2u, 3u}));
     lpc_scheme_prover.append_to_batch(1, poly_type(2, {0u, 1u, 3u, 4u}));
-    lpc_scheme_prover.append_to_batch(2, poly_type(0, {0u}));
+    lpc_scheme_prover.append_to_batch(2, poly_type(0, std::initializer_list<value_type>{0u}));
     lpc_scheme_prover.append_to_batch(3, generate_random_polynomial_dfs(3, test_global_alg_rnd_engine<FieldType>));
     lpc_scheme_prover.append_to_batch(3, generate_random_polynomial_dfs(7, test_global_alg_rnd_engine<FieldType>));
 

--- a/crypto3/libs/marshalling/zk/test/fri_commitment.cpp
+++ b/crypto3/libs/marshalling/zk/test/fri_commitment.cpp
@@ -251,9 +251,9 @@ BOOST_AUTO_TEST_CASE(marshalling_fri_basic_test) {
             );
 
     // commit
-    math::polynomial<typename field_type::value_type> f = {{
+    math::polynomial_dfs<typename field_type::value_type> f = {15, {
         1u, 3u, 4u, 1u, 5u, 6u, 7u, 2u, 8u, 7u, 5u, 6u, 1u, 2u, 1u, 1u}};
-    std::array<std::vector<math::polynomial<typename field_type::value_type>>, 1> fs;
+    std::array<std::vector<math::polynomial_dfs<typename field_type::value_type>>, 1> fs;
     fs[0].resize(1);
     fs[0][0] = f;
     typename fri_type::merkle_tree_type tree = zk::algorithms::precommit<fri_type>(

--- a/crypto3/libs/marshalling/zk/test/lpc_commitment.cpp
+++ b/crypto3/libs/marshalling/zk/test/lpc_commitment.cpp
@@ -153,7 +153,7 @@ BOOST_AUTO_TEST_SUITE(marshalling_random)
     static constexpr std::size_t lambda = 40;
     static constexpr std::size_t m = 2;
 
-    constexpr static const std::size_t d = 16;
+    constexpr static const std::size_t d = 15;
     constexpr static const std::size_t final_polynomial_degree = 1; // final polynomial degree
     constexpr static const std::size_t r = boost::static_log2<(d - final_polynomial_degree)>::value;
 
@@ -169,7 +169,8 @@ BOOST_AUTO_TEST_SUITE(marshalling_random)
             hash_type, hash_type, m
     >;
     using LPC = typename nil::crypto3::zk::commitments::batched_list_polynomial_commitment<field_type, lpc_params_type>;
-    using lpc_scheme_type = nil::crypto3::zk::commitments::lpc_commitment_scheme<LPC, math::polynomial<typename field_type::value_type>>;
+    using poly_type = math::polynomial_dfs<typename field_type::value_type>;
+    using lpc_scheme_type = nil::crypto3::zk::commitments::lpc_commitment_scheme<LPC, poly_type>;
 
 BOOST_FIXTURE_TEST_CASE(lpc_proof_test, test_tools::random_test_initializer<field_type>) {
 
@@ -216,7 +217,7 @@ BOOST_FIXTURE_TEST_CASE(batches_num_3_test, test_tools::random_test_initializer<
     constexpr static const std::size_t lambda = 40;
     constexpr static const std::size_t k = 1;
 
-    constexpr static const std::size_t d = 16;
+    constexpr static const std::size_t d = 15;
 
     constexpr static const std::size_t r = boost::static_log2<(d - k)>::value;
     constexpr static const std::size_t m = 2;
@@ -227,6 +228,7 @@ BOOST_FIXTURE_TEST_CASE(batches_num_3_test, test_tools::random_test_initializer<
         list_polynomial_commitment_params<merkle_hash_type, transcript_hash_type, m>
             lpc_params_type;
     typedef zk::commitments::list_polynomial_commitment<field_type, lpc_params_type> lpc_type;
+    typedef math::polynomial_dfs<typename field_type::value_type> poly_type;
 
     static_assert(zk::is_commitment<fri_type>::value);
     static_assert(zk::is_commitment<lpc_type>::value);
@@ -244,15 +246,15 @@ BOOST_FIXTURE_TEST_CASE(batches_num_3_test, test_tools::random_test_initializer<
         2 /*expand_factor*/
     );
 
-    using lpc_scheme_type = nil::crypto3::zk::commitments::lpc_commitment_scheme<lpc_type, math::polynomial<typename field_type::value_type>>;
+    using lpc_scheme_type = nil::crypto3::zk::commitments::lpc_commitment_scheme<lpc_type, poly_type>;
     lpc_scheme_type lpc_scheme_prover(fri_params);
 
     // Generate polynomials
-    lpc_scheme_prover.append_to_batch(0, {1u, 13u, 4u, 1u, 5u, 6u, 7u, 2u, 8u, 7u, 5u, 6u, 1u, 2u, 1u, 1u});
-    lpc_scheme_prover.append_to_batch(2, {0u, 1u});
-    lpc_scheme_prover.append_to_batch(2, {0u, 1u, 2u});
-    lpc_scheme_prover.append_to_batch(2, {0u, 1u, 3u});
-    lpc_scheme_prover.append_to_batch(3, {0u});
+    lpc_scheme_prover.append_to_batch(0, poly_type(15, {1u, 13u, 4u, 1u, 5u, 6u, 7u, 2u, 8u, 7u, 5u, 6u, 1u, 2u, 1u, 1u}));
+    lpc_scheme_prover.append_to_batch(2, poly_type(1, {0u, 1u}));
+    lpc_scheme_prover.append_to_batch(2, poly_type(2, {0u, 1u, 2u, 3u}));
+    lpc_scheme_prover.append_to_batch(3, poly_type(2, {0u, 1u, 3u, 4u}));
+    lpc_scheme_prover.append_to_batch(3, poly_type(0, {0u}));
 
     // Commit
     std::map<std::size_t, typename lpc_type::commitment_type> commitments;

--- a/crypto3/libs/marshalling/zk/test/lpc_commitment.cpp
+++ b/crypto3/libs/marshalling/zk/test/lpc_commitment.cpp
@@ -208,6 +208,8 @@ BOOST_AUTO_TEST_SUITE(marshalling_real)
     using Endianness = nil::crypto3::marshalling::option::big_endian;
     using curve_type = nil::crypto3::algebra::curves::vesta;
     using field_type = curve_type::scalar_field_type;
+    using value_type = field_type::value_type;
+
     using merkle_hash_type = nil::crypto3::hashes::keccak_1600<256>;
     using transcript_hash_type = nil::crypto3::hashes::keccak_1600<256>;
     using merkle_tree_type = typename containers::merkle_tree<merkle_hash_type, 2>;
@@ -228,7 +230,7 @@ BOOST_FIXTURE_TEST_CASE(batches_num_3_test, test_tools::random_test_initializer<
         list_polynomial_commitment_params<merkle_hash_type, transcript_hash_type, m>
             lpc_params_type;
     typedef zk::commitments::list_polynomial_commitment<field_type, lpc_params_type> lpc_type;
-    typedef math::polynomial_dfs<typename field_type::value_type> poly_type;
+    typedef math::polynomial_dfs<value_type> poly_type;
 
     static_assert(zk::is_commitment<fri_type>::value);
     static_assert(zk::is_commitment<lpc_type>::value);
@@ -254,7 +256,7 @@ BOOST_FIXTURE_TEST_CASE(batches_num_3_test, test_tools::random_test_initializer<
     lpc_scheme_prover.append_to_batch(2, poly_type(1, {0u, 1u}));
     lpc_scheme_prover.append_to_batch(2, poly_type(2, {0u, 1u, 2u, 3u}));
     lpc_scheme_prover.append_to_batch(3, poly_type(2, {0u, 1u, 3u, 4u}));
-    lpc_scheme_prover.append_to_batch(3, poly_type(0, {0u}));
+    lpc_scheme_prover.append_to_batch(3, poly_type(0, std::initializer_list<value_type>{0u}));
 
     // Commit
     std::map<std::size_t, typename lpc_type::commitment_type> commitments;

--- a/crypto3/libs/zk/include/nil/crypto3/zk/commitments/detail/polynomial/basic_fri.hpp
+++ b/crypto3/libs/zk/include/nil/crypto3/zk/commitments/detail/polynomial/basic_fri.hpp
@@ -1008,21 +1008,6 @@ namespace nil {
                     typename FRI::initial_proofs_batch_type proof;
                     proof.initial_proofs.resize(fri_params.lambda);
 
-                    // If we have DFS polynomials, and we are going to resize them, better
-                    // convert them to coefficients form, and compute their values in
-                    // those 2 * FRI::lambda points each, which is normally 2 * 20. In
-                    // case lambda becomes much larger than log(2, average polynomial
-                    // size), then this will not be optimal. For lambda = 20 and 2^20 rows
-                    // in assignment table, it's faster and uses less RAM.
-                    TAGGED_PROFILE_SCOPE("{low level} FFT",
-                                         "Convert g polynomials to coefficients");
-                    std::map<std::size_t,
-                             std::vector<typename polynomial_dfs_type::polynomial_type>>
-                        g_coeffs =
-                            convert_polynomials_to_coefficients<FRI, polynomial_dfs_type>(
-                                fri_params, g);
-                    PROFILE_SCOPE_END();
-
                     TAGGED_PROFILE_SCOPE("{low level} poly eval",
                                          "Compute initial proofs of size {}",
                                          fri_params.lambda);

--- a/crypto3/libs/zk/include/nil/crypto3/zk/commitments/polynomial/fri.hpp
+++ b/crypto3/libs/zk/include/nil/crypto3/zk/commitments/polynomial/fri.hpp
@@ -95,7 +95,7 @@ namespace nil {
                 // Proof and verify for one polynomial
                 // One polynomial processing
                 template<typename FRI,
-                    typename PolynomialType,
+                    typename polynomial_dfs_type,
                     typename std::enable_if<std::is_base_of<commitments::fri<typename FRI::field_type,
                             typename FRI::merkle_tree_hash_type,
                             typename FRI::transcript_hash_type,
@@ -105,16 +105,22 @@ namespace nil {
                         FRI>::value,
                     bool>::type = true>
                 static typename FRI::basic_fri::proof_type proof_eval(
-                    PolynomialType &g,
+                    polynomial_dfs_type &g,
                     typename FRI::basic_fri::merkle_tree_type &tree,
                     const typename FRI::params_type &fri_params,
                     typename FRI::transcript_type &transcript = typename FRI::transcript_type()
-                ){
-                    std::map<std::size_t, std::vector<PolynomialType>> gs;
-                    gs[0]={g};
+                ) {
+                    using polynomial_type = typename polynomial_dfs_type::polynomial_type;
+
+                    std::map<std::size_t, std::vector<polynomial_dfs_type>> gs;
+                    gs[0] = {g};
+                    std::map<std::size_t, std::vector<polynomial_type>> gs_coefficients;
+                    gs_coefficients[0] = {polynomial_type(g.coefficients())};
+
                     std::map<std::size_t, typename FRI::basic_fri::merkle_tree_type> trees;
                     trees[0] = typename FRI::basic_fri::merkle_tree_type(tree);
-                    return proof_eval<FRI, PolynomialType>(gs, g, trees, tree, fri_params, transcript);
+                    
+                    return proof_eval<FRI, polynomial_dfs_type>(gs, gs_coefficients, g, trees, tree, fri_params, transcript);
                 }
 
                 template<typename FRI,

--- a/crypto3/libs/zk/include/nil/crypto3/zk/commitments/polynomial/fri.hpp
+++ b/crypto3/libs/zk/include/nil/crypto3/zk/commitments/polynomial/fri.hpp
@@ -95,15 +95,15 @@ namespace nil {
                 // Proof and verify for one polynomial
                 // One polynomial processing
                 template<typename FRI,
-                    typename polynomial_dfs_type,
-                    typename std::enable_if<std::is_base_of<commitments::fri<typename FRI::field_type,
+                    typename polynomial_dfs_type>
+                    requires(
+                        std::is_base_of<commitments::fri<typename FRI::field_type,
                             typename FRI::merkle_tree_hash_type,
                             typename FRI::transcript_hash_type,
                             FRI::m,
                             typename FRI::grinding_type
-                        >,
-                        FRI>::value,
-                    bool>::type = true>
+                        >, FRI>::value && 
+                        math::is_any_polynomial_dfs<polynomial_dfs_type>::value)
                 static typename FRI::basic_fri::proof_type proof_eval(
                     polynomial_dfs_type &g,
                     typename FRI::basic_fri::merkle_tree_type &tree,

--- a/crypto3/libs/zk/include/nil/crypto3/zk/commitments/polynomial/lpc.hpp
+++ b/crypto3/libs/zk/include/nil/crypto3/zk/commitments/polynomial/lpc.hpp
@@ -95,6 +95,9 @@ namespace nil {
                     const value_type& get_etha() const {return _etha;}
                     const std::map<std::size_t, bool>& get_batch_fixed() const {return _batch_fixed;}
                     const preprocessed_data_type& get_fixed_polys_values() const {return _fixed_polys_values;}
+                    const std::map<std::size_t, std::vector<typename polynomial_dfs_type::polynomial_type>>& get_polys_coefficients() const {
+                        return _polys_coefficients;
+                    }
 
                     // We must set it in verifier, taking this value from common data.
                     void set_fixed_polys_values(const preprocessed_data_type& value) {_fixed_polys_values = value;}
@@ -107,13 +110,16 @@ namespace nil {
                             const typename fri_type::params_type& fri_params,
                             const value_type& etha,
                             const std::map<std::size_t, bool>& batch_fixed,
-                            const preprocessed_data_type& fixed_polys_values)
+                            const preprocessed_data_type& fixed_polys_values,
+                            std::map<std::size_t, std::vector<typename polynomial_dfs_type::polynomial_type>> polys_coefficients
+                            )
                         : polys_evaluator_type(polys_evaluator)
                         , _trees(trees)
                         , _fri_params(fri_params)
                         , _etha(etha)
                         , _batch_fixed(batch_fixed)
                         , _fixed_polys_values(fixed_polys_values)
+                        , _polys_coefficients(std::move(polys_coefficients))
                     {
                     }
 

--- a/crypto3/libs/zk/include/nil/crypto3/zk/commitments/polynomial/lpc.hpp
+++ b/crypto3/libs/zk/include/nil/crypto3/zk/commitments/polynomial/lpc.hpp
@@ -184,8 +184,6 @@ namespace nil {
 
                         eval_polys_and_add_roots_to_transcipt(transcript);
 
-                        convert_polys_to_coefficients_form();
-
                         // Prepare z-s and combined_Q;
                         auto theta = transcript.template challenge<field_type>();
                         polynomial_type combined_Q = prepare_combined_Q(theta);
@@ -216,9 +214,11 @@ namespace nil {
                     lpc_proof_type proof_eval_lpc_proof(
                             const std::vector<typename fri_type::field_type::value_type>& challenges) {
 
+                        // This is normally called from DFRI, and we don't have polys in coefficients form ready.
+                        convert_polys_to_coefficients_form();
                         typename fri_type::initial_proofs_batch_type initial_proofs =
                             nil::crypto3::zk::algorithms::query_phase_initial_proofs<fri_type, polynomial_type>(
-                            this->_trees, this->_fri_params, this->_polys, challenges);
+                            this->_trees, this->_fri_params, this->_polys, this->_polys_coefficients, challenges);
                         return {this->_z, initial_proofs};
                     }
 
@@ -322,6 +322,7 @@ namespace nil {
                         PROFILE_SCOPE("LPC prepare combined Q");
 
                         this->build_points_map();
+                        convert_polys_to_coefficients_form();
 
                         value_type theta_acc = theta.pow(starting_power);
                         auto points = this->get_unique_points();

--- a/crypto3/libs/zk/test/commitment/fri.cpp
+++ b/crypto3/libs/zk/test/commitment/fri.cpp
@@ -133,15 +133,6 @@ void fri_basic_test()
 
 }
 
-BOOST_AUTO_TEST_CASE(fri_basic_test_polynomial) {
-
-    using curve_type = algebra::curves::pallas;
-    using FieldType = typename curve_type::base_field_type;
-    using PolynomialType = math::polynomial<FieldType::value_type>;
-
-    fri_basic_test<FieldType, PolynomialType>();
-}
-
 BOOST_AUTO_TEST_CASE(fri_basic_test_polynomial_dfs) {
 
     using curve_type = algebra::curves::pallas;

--- a/crypto3/libs/zk/test/commitment/lpc.cpp
+++ b/crypto3/libs/zk/test/commitment/lpc.cpp
@@ -124,10 +124,11 @@ BOOST_AUTO_TEST_SUITE(lpc_math_polynomial_suite);
         // Setup types.
         typedef algebra::curves::bls12<381> curve_type;
         typedef typename curve_type::scalar_field_type FieldType;
+        typedef typename FieldType::value_type value_type;
         typedef hashes::sha2<256> merkle_hash_type;
         typedef hashes::sha2<256> transcript_hash_type;
         typedef typename containers::merkle_tree<merkle_hash_type, 2> merkle_tree_type;
-        typedef typename math::polynomial_dfs<typename FieldType::value_type> poly_type;
+        typedef typename math::polynomial_dfs<value_type> poly_type;
 
         constexpr static const std::size_t lambda = 10;
         constexpr static const std::size_t k = 1;
@@ -167,7 +168,7 @@ BOOST_AUTO_TEST_SUITE(lpc_math_polynomial_suite);
                 12 // grinding_parameter
                 );
 
-        using lpc_scheme_type = nil::crypto3::zk::commitments::lpc_commitment_scheme<lpc_type, math::polynomial_dfs<typename FieldType::value_type>>;
+        using lpc_scheme_type = nil::crypto3::zk::commitments::lpc_commitment_scheme<lpc_type, poly_type>;
         lpc_scheme_type lpc_scheme_prover(fri_params);
         lpc_scheme_type lpc_scheme_verifier(fri_params);
 
@@ -176,7 +177,7 @@ BOOST_AUTO_TEST_SUITE(lpc_math_polynomial_suite);
         lpc_scheme_prover.append_to_batch(1, poly_type(1, {0u, 1u}));
         lpc_scheme_prover.append_to_batch(1, poly_type(2, {0u, 1u, 2u, 3u}));
         lpc_scheme_prover.append_to_batch(1, poly_type(2, {0u, 1u, 3u, 4u}));
-        lpc_scheme_prover.append_to_batch(2, poly_type(0, {0u}));
+        lpc_scheme_prover.append_to_batch(2, poly_type(0, std::initializer_list<value_type>{0u}));
         lpc_scheme_prover.append_to_batch(3, generate_random_polynomial_dfs(3, test_global_alg_rnd_engine<FieldType>));
         lpc_scheme_prover.append_to_batch(3, generate_random_polynomial_dfs(7, test_global_alg_rnd_engine<FieldType>));
 
@@ -224,6 +225,7 @@ BOOST_AUTO_TEST_SUITE(lpc_math_polynomial_suite);
         // Setup types
         typedef algebra::curves::bls12<381> curve_type;
         typedef typename curve_type::scalar_field_type FieldType;
+        typedef typename FieldType::value_type value_type;
 
         typedef hashes::sha2<256> merkle_hash_type;
         typedef hashes::sha2<256> transcript_hash_type;
@@ -267,7 +269,7 @@ BOOST_AUTO_TEST_SUITE(lpc_math_polynomial_suite);
                 2 //expand_factor
                 );
 
-        using lpc_scheme_type = nil::crypto3::zk::commitments::lpc_commitment_scheme<lpc_type, math::polynomial_dfs<typename FieldType::value_type>>;
+        using lpc_scheme_type = nil::crypto3::zk::commitments::lpc_commitment_scheme<lpc_type, math::polynomial_dfs<value_type>>;
         lpc_scheme_type lpc_scheme_prover(fri_params);
         lpc_scheme_type lpc_scheme_verifier(fri_params);
 
@@ -422,10 +424,11 @@ BOOST_AUTO_TEST_SUITE(lpc_params_test_suite)
         // Setup types.
         typedef algebra::curves::bls12<381> curve_type;
         typedef typename curve_type::scalar_field_type FieldType;
+        typedef typename FieldType::value_type value_type;
         typedef hashes::sha2<256> merkle_hash_type;
         typedef hashes::sha2<256> transcript_hash_type;
         typedef typename containers::merkle_tree<merkle_hash_type, 2> merkle_tree_type;
-        typedef typename math::polynomial_dfs<typename FieldType::value_type> poly_type;
+        typedef typename math::polynomial_dfs<value_type> poly_type;
 
         constexpr static const std::size_t lambda = 40;
         constexpr static const std::size_t k = 1;
@@ -459,7 +462,7 @@ BOOST_AUTO_TEST_SUITE(lpc_params_test_suite)
                 8
                 );
 
-        using lpc_scheme_type = nil::crypto3::zk::commitments::lpc_commitment_scheme<lpc_type, math::polynomial_dfs<typename FieldType::value_type>>;
+        using lpc_scheme_type = nil::crypto3::zk::commitments::lpc_commitment_scheme<lpc_type, poly_type>;
         lpc_scheme_type lpc_scheme_prover(fri_params);
         lpc_scheme_type lpc_scheme_verifier(fri_params);
 
@@ -468,7 +471,7 @@ BOOST_AUTO_TEST_SUITE(lpc_params_test_suite)
         lpc_scheme_prover.append_to_batch(2, poly_type(1, {0u, 1u}));
         lpc_scheme_prover.append_to_batch(2, poly_type(2, {0u, 1u, 2u, 3u}));
         lpc_scheme_prover.append_to_batch(2, poly_type(2, {0u, 1u, 3u, 4u}));
-        lpc_scheme_prover.append_to_batch(3, poly_type(0, {0u}));
+        lpc_scheme_prover.append_to_batch(3, poly_type(0, std::initializer_list<value_type>{0u}));
  
         // Commit
         std::map<std::size_t, typename lpc_type::commitment_type> commitments;
@@ -511,10 +514,11 @@ BOOST_AUTO_TEST_SUITE(lpc_params_test_suite)
         // Setup types.
         typedef algebra::curves::bls12<381> curve_type;
         typedef typename curve_type::scalar_field_type FieldType;
+        typedef typename FieldType::value_type value_type;
         typedef hashes::keccak_1600<256> merkle_hash_type;
         typedef hashes::sha2<256> transcript_hash_type;
         typedef typename containers::merkle_tree<merkle_hash_type, 2> merkle_tree_type;
-        typedef typename math::polynomial_dfs<typename FieldType::value_type> poly_type;
+        typedef typename math::polynomial_dfs<value_type> poly_type;
 
         constexpr static const std::size_t lambda = 10;
         constexpr static const std::size_t k = 1;
@@ -551,7 +555,7 @@ BOOST_AUTO_TEST_SUITE(lpc_params_test_suite)
                 2 //expand_factor
                 );
 
-        using lpc_scheme_type = nil::crypto3::zk::commitments::lpc_commitment_scheme<lpc_type, math::polynomial_dfs<typename FieldType::value_type>>;
+        using lpc_scheme_type = nil::crypto3::zk::commitments::lpc_commitment_scheme<lpc_type, poly_type>;
         lpc_scheme_type lpc_scheme_prover(fri_params);
         lpc_scheme_type lpc_scheme_verifier(fri_params);
 
@@ -560,7 +564,7 @@ BOOST_AUTO_TEST_SUITE(lpc_params_test_suite)
         lpc_scheme_prover.append_to_batch(2, poly_type(1, {0u, 1u}));
         lpc_scheme_prover.append_to_batch(2, poly_type(2, {0u, 1u, 2u, 3u}));
         lpc_scheme_prover.append_to_batch(2, poly_type(2, {0u, 1u, 3u, 4u}));
-        lpc_scheme_prover.append_to_batch(3, poly_type(0, {0u}));
+        lpc_scheme_prover.append_to_batch(3, poly_type(0, std::initializer_list<value_type>{0u}));
         lpc_scheme_prover.append_to_batch(3, generate_random_polynomial_dfs(3, test_global_alg_rnd_engine<FieldType>));
         lpc_scheme_prover.append_to_batch(3, generate_random_polynomial_dfs(7, test_global_alg_rnd_engine<FieldType>));
 

--- a/proof-producer/benchmarks/requirements.txt
+++ b/proof-producer/benchmarks/requirements.txt
@@ -16,7 +16,7 @@ opentelemetry-sdk==1.30.0
 opentelemetry-semantic-conventions==0.51b0
 protobuf==5.29.3
 PyYAML==6.0.2
-requests==2.32.3
+requests==2.32.4
 typing_extensions==4.12.2
 urllib3==2.3.0
 wrapt==1.17.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-requests==2.32.2
+requests==2.32.4
 opentelemetry-distro[otlp]==0.45b0
 opentelemetry-instrumentation-requests==0.45b0
 opentelemetry-util-http==0.45b0


### PR DESCRIPTION
- Clean the code of LPC
- Use addition point _etha much easier
- Don't convert committed polynomials to coefficients form twice.
- Allow committing to polynomials only in DFS form in LPC.